### PR TITLE
Remove community.kubernetes collection and only use kubernetes.core

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,5 @@
 ---
 collections:
-  - name: community.kubernetes
-    version: "2.0.1"
   - name: operator_sdk.util
     version: "0.4.0"
   - name: kubernetes.core


### PR DESCRIPTION
So far we have no need for the community.kubernetes collection, all the k8s modules we use are provided by the kubernetes.core collection.  To eliminate confusion, let's remove the requirement for community.kubernetes.  