### PR TITLE
Remove duplicate DB_HOST secret env var

### DIFF
--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -79,8 +79,6 @@ spec:
             secretKeyRef:
               name: '{{ __postgres_configuration_secret }}'
               key: password
-        - name: EDA_DB_HOST
-          value: eda-postgres
         - name: EDA_MQ_HOST
           value: {{ ansible_operator_meta.name }}-redis-svc
         ports:


### PR DESCRIPTION
Previously, when a project was created in the UI, the worker container would error in the logs because it could not connect to the database.  This was because of a duplicate EDA_DB_HOST variable left behind from the first iteration of this operator.  

Removing this allows us to successfully sync projects and populate rules.

![image](https://user-images.githubusercontent.com/11698892/228123668-09aa1cb5-67a1-420d-a5a5-01018209679b.png)
