### PR TITLE
Rename postgres params section to database

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -1211,9 +1211,12 @@ spec:
                       type: object
                     type: array
                 type: object
-              postgres:
-                description: The EDA postgres StatefulSet
+              database:
+                description: The EDA PostgreSQL database StatefulSet
                 properties:
+                  database_secret:
+                    description: Secret where the database configuration can be found. Set this to us your own external PostgreSQL database. If not specified, this secret will be generated and EDA will not create a managed postgres pod.
+                    type: string
                   resource_requirements:
                     description: Resource requirements for the database container.
                     properties:
@@ -1341,9 +1344,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              postgres_configuration_secret:
-                description: Secret where the database configuration can be found
-                type: string
               postgres_image:
                 description: Registry path to the PostgreSQL container to use
                 type: string
@@ -1437,14 +1437,14 @@ spec:
                   type: object
                 type: array
               secret_key_secret:
-                description: Secret where the secret key can be found
+                description: Secret where the secret key can be found. If not specified, one will be generated.
                 type: string
               admin_user:
                 description: Username to use for the admin account
                 type: string
                 default: admin
               admin_password_secret:
-                description: Secret where the admin password can be found
+                description: Secret where the admin password can be found. If not specified, one will be generated.
                 type: string
           status:
             description: Status defines the observed state of EDA

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -26,8 +26,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: Secret Key
-        description: Name of the k8s secret the symmetric encryption key is stored in.
+      - description: Name of the k8s secret the symmetric encryption key is stored
+          in.
+        displayName: Secret Key
         path: secret_key_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -60,51 +61,44 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: Database configuration secret
-        path: postgres_configuration_secret
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:io.kubernetes:Secret
       - displayName: API Extra Settings
         path: extra_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: PostgreSQL server configuration
-        path: postgres
+      - displayName: PostgreSQL Database configuration
+        path: database
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: PostgreSQL server resource requirements
-        path: postgres.resource_requirements
+      - displayName: External database configuration secret
+        path: database.database_secret
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Database resource requirements
+        path: database.resource_requirements
+        x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - description: Define Postgres storage requirements
-        displayName: Postgres Storage Requirements
-        path: postgres.storage_requirements
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Postgres Priority Class
-        path: postgres.priority_class
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Define Database storage requirements
+        displayName: Database Storage Requirements
+        path: database.storage_requirements
       - description: 'Configure PostgreSQL connection sslmode option. Default: "prefer"'
-        displayName: Postgres SSLMode
-        path: postgres.postgres_ssl_mode
+        displayName: Database SSLMode
+        path: database.postgres_ssl_mode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Name of the StorageClass required by the claim.
-        displayName: Postgres Storage Class
-        path: postgres.postgres_storage_class
+        displayName: Database Storage Class
+        path: database.postgres_storage_class
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:StorageClass
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Database data path
-        path: postgres.postgres_data_path
+        path: database.postgres_data_path
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Postgres Extra Arguments
-        path: postgres.postgres_extra_args
+      - displayName: Database Extra Arguments
+        path: database.postgres_extra_args
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
@@ -118,15 +112,19 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Postgres Selector
-        path: postgres.node_selector
+      - displayName: Database Selector
+        path: database.node_selector
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Postgres Tolerations
-        path: postgres.tolerations
+      - displayName: Database Tolerations
+        path: database.tolerations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Database Priority Class
+        path: database.priority_class
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Defines desired state of eda-api deployment resources
         displayName: API deployment configuration
         path: api

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -57,27 +57,27 @@ spec:
         - name: EDA_DB_HOST
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: host
         - name: EDA_DB_NAME
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: database
         - name: EDA_DB_PORT
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: port
         - name: EDA_DB_USER
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: username
         - name: EDA_DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: password
         - name: EDA_ALLOWED_HOSTS
           value: "['*']"

--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -57,27 +57,27 @@ spec:
         - name: EDA_DB_HOST
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: host
         - name: EDA_DB_NAME
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: database
         - name: EDA_DB_PORT
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: port
         - name: EDA_DB_USER
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: username
         - name: EDA_DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: '{{ __postgres_configuration_secret }}'
+              name: '{{ __database_secret }}'
               key: password
         - name: EDA_DB_HOST
           value: eda-postgres

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -5,7 +5,7 @@ database_name: "{{ deployment_type }}"
 database_username: "{{ deployment_type }}"
 
 # Name of k8s secret containing postgres host, username, password, database, port, and type
-postgres_configuration_secret: ''
+database_secret: ''
 
 _postgres_image: docker.io/library/postgres
 _postgres_image_version: 13

--- a/roles/postgres/tasks/set_configuration_secret.yml
+++ b/roles/postgres/tasks/set_configuration_secret.yml
@@ -3,9 +3,9 @@
   k8s_info:
     kind: Secret
     namespace: '{{ ansible_operator_meta.namespace }}'
-    name: '{{ postgres_configuration_secret }}'
+    name: '{{ database_secret }}'
   register: _custom_pg_config_resources
-  when: postgres_configuration_secret | length
+  when: database_secret | length
   no_log: "{{ no_log }}"
 
 - name: Check for default PostgreSQL configuration
@@ -44,4 +44,4 @@
 
 - name: Set actual postgres configuration secret used
   set_fact:
-    __postgres_configuration_secret: "{{ pg_config['resources'][0]['metadata']['name'] }}"
+    __database_secret: "{{ pg_config['resources'][0]['metadata']['name'] }}"

--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -37,60 +37,60 @@ spec:
           type: RuntimeDefault
         capabilities:
           drop: ["ALL"]
-{% if postgres.priority_class is defined %}
-      priorityClassName: '{{ postgres.priority_class }}'
+{% if database.priority_class is defined %}
+      priorityClassName: '{{ database.priority_class }}'
 {% endif %}
-{% if postgres.node_selector %}
+{% if database.node_selector %}
       nodeSelector:
-        {{ postgres.node_selector | indent(width=8) }}
+        {{ database.node_selector | indent(width=8) }}
 {% endif %}
-{% if postgres.tolerations %}
+{% if database.tolerations %}
       tolerations:
-        {{ postgres.tolerations | indent(width=8) }}
+        {{ database.tolerations | indent(width=8) }}
 {% endif %}
       containers:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
-{% if postgres.postgres_extra_args %}
-          args: {{ postgres.postgres_extra_args }}
+{% if database.postgres_extra_args %}
+          args: {{ database.postgres_extra_args }}
 {% endif %}
           env:
             # For postgres_image based on rhel8/postgresql-13
             - name: POSTGRESQL_DATABASE
               valueFrom:
                 secretKeyRef:
-                  name: '{{ __postgres_configuration_secret }}'
+                  name: '{{ __database_secret }}'
                   key: database
             - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
-                  name: '{{ __postgres_configuration_secret }}'
+                  name: '{{ __database_secret }}'
                   key: username
             - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: '{{ __postgres_configuration_secret }}'
+                  name: '{{ __database_secret }}'
                   key: password
 
             # For postgres_image based on postgres
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: '{{ __postgres_configuration_secret }}'
+                  name: '{{ __database_secret }}'
                   key: database
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: '{{ __postgres_configuration_secret }}'
+                  name: '{{ __database_secret }}'
                   key: username
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: '{{ __postgres_configuration_secret }}'
+                  name: '{{ __database_secret }}'
                   key: password
             - name: PGDATA
-              value: '{{ postgres.postgres_data_path }}'
+              value: '{{ database.postgres_data_path }}'
             - name: POSTGRES_INITDB_ARGS
               value: '{{ postgres_initdb_args }}'
             - name: POSTGRES_HOST_AUTH_METHOD
@@ -100,10 +100,10 @@ spec:
               name: postgres-{{ supported_pg_version }}
           volumeMounts:
             - name: postgres-{{ supported_pg_version }}
-              mountPath: '{{ postgres.postgres_data_path | dirname }}'
-              subPath: '{{ postgres.postgres_data_path | dirname | basename }}'
-{% if postgres.resource_requirements is defined %}
-          resources: {{ postgres.resource_requirements }}
+              mountPath: '{{ database.postgres_data_path | dirname }}'
+              subPath: '{{ database.postgres_data_path | dirname | basename }}'
+{% if database.resource_requirements is defined %}
+          resources: {{ database.resource_requirements }}
 {% endif %}
   volumeClaimTemplates:
     - metadata:
@@ -114,4 +114,4 @@ spec:
 {% if postgres_storage_class is defined %}
         storageClassName: '{{ database.postgres_storage_class }}'
 {% endif %}
-        resources: {{ postgres.storage_requirements }}
+        resources: {{ database.storage_requirements }}


### PR DESCRIPTION
To align with the pulp-operator, and were we hope to head with the awx-operator, let's rename the nested `postgres` settings to `database`

These settings will show under a nested section whose key is `database`:

![image](https://user-images.githubusercontent.com/11698892/228129010-5348a325-bc84-4d0e-aa66-7d1e237ea841.png)


Here is a screenshot of that section expanded. 

![image](https://user-images.githubusercontent.com/11698892/228131226-5267f8cd-99fa-4106-a914-e4af1d55d73a.png)
