### PR TITLE
Combine component defaults with user defined parameters

### DIFF
--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -19,7 +19,8 @@ _ui_image_version: latest
 #     kubernetes.io/arch: amd64
 #     kubernetes.io/os: linux
 
-api:
+api: {}
+_api:
   replicas: 1
   resource_requirements:
     requests:
@@ -28,7 +29,8 @@ api:
   node_selector: ''
   tolerations: ''
 
-worker:
+worker: {}
+_worker:
   replicas: 1
   resource_requirements:
     requests:
@@ -37,7 +39,8 @@ worker:
   node_selector: ''
   tolerations: ''
 
-ui:
+ui: {}
+_ui:
   replicas: 1
   resource_requirements:
     requests:

--- a/roles/eda/tasks/combine_defaults.yml
+++ b/roles/eda/tasks/combine_defaults.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Combine default and custom variables from the CR for each component
+  set_fact:
+    combined_api: "{{ api | combine ( _api ) }}"
+    combined_ui: "{{ ui | combine ( _ui ) }}"
+    combined_worker: "{{ worker | combine ( _worker ) }}"

--- a/roles/eda/tasks/main.yml
+++ b/roles/eda/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 # tasks file for EDA
 
+- name: Combine default and custom vars for each component
+  include_tasks: combine_defaults.yml
+
 - name: Configure cluster
   include_role:
     name: common
@@ -9,7 +12,7 @@
   include_role:
     name: postgres
 
-- name: Setup Redis Cache
+- name: Setup Redis
   include_role:
     name: redis
 

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -9,16 +9,16 @@ metadata:
   name: '{{ ansible_operator_meta.name }}-api'
   namespace: '{{ ansible_operator_meta.namespace }}'
 spec:
-  replicas: {{ api.replicas }}
-{% if api.strategy is defined %}
+  replicas: {{ combined_api.replicas }}
+{% if combined_api.strategy is defined %}
   strategy:
-    type: {{ api.strategy.type }}
-{% if api.strategy.type == "Recreate" %}
+    type: {{ combined_api.strategy.type }}
+{% if combined_api.strategy.type == "Recreate" %}
     rollingUpdate: null
-{% elif api.strategy.type == "RollingUpdate" %}
+{% elif combined_api.strategy.type == "RollingUpdate" %}
     rollingUpdate:
-      maxSurge:  {{ api.strategy.rollingUpdate.maxSurge | default("25%")}}
-      maxUnavailable: {{ api.strategy.rollingUpdate.maxUnavailable | default("25%")}}
+      maxSurge:  {{ combined_api.strategy.rollingUpdate.maxSurge | default("25%")}}
+      maxUnavailable: {{ combined_api.strategy.rollingUpdate.maxUnavailable | default("25%")}}
 {% endif %}
 {% endif %}
   selector:
@@ -33,17 +33,17 @@ spec:
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-api'
     spec:
-{% if api.node_selector is defined %}
+{% if combined_api.node_selector is defined %}
       nodeSelector:
-        {{ api.node_selector | indent(width=8) }}
+        {{ combined_api.node_selector | indent(width=8) }}
 {% endif %}
-{% if api.tolerations is defined %}
+{% if combined_api.tolerations is defined %}
       tolerations:
-        {{ api.tolerations | indent(width=8) }}
+        {{ combined_api.tolerations | indent(width=8) }}
 {% endif %}
-{% if api.topology_spread_constraints is defined %}
+{% if combined_api.topology_spread_constraints is defined %}
       topologySpreadConstraints:
-        {{ api.topology_spread_constraints | indent(width=8) }}
+        {{ combined_api.topology_spread_constraints | indent(width=8) }}
 {% endif %}
       containers:
       - name: eda-api
@@ -90,8 +90,8 @@ spec:
               key: secret_key
         ports:
         - containerPort: 8000
-{% if api.resource_requirements is defined %}
-        resources: {{ api.resource_requirements }}
+{% if combined_api.resource_requirements is defined %}
+        resources: {{ combined_api.resource_requirements }}
 {% endif %}
         volumeMounts:
           - name: {{ ansible_operator_meta.name }}-settings

--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -9,16 +9,16 @@ metadata:
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
     app.kubernetes.io/component: '{{ deployment_type }}-ui'
 spec:
-  replicas: {{ ui.replicas }}
-{% if ui.strategy is defined %}
+  replicas: {{ combined_ui.replicas }}
+{% if combined_ui.strategy is defined %}
   strategy:
-    type: {{ ui.strategy.type }}
-{% if ui.strategy.type == "Recreate" %}
+    type: {{ combined_ui.strategy.type }}
+{% if combined_ui.strategy.type == "Recreate" %}
     rollingUpdate: null
-{% elif ui.strategy.type == "RollingUpdate" %}
+{% elif combined_ui.strategy.type == "RollingUpdate" %}
     rollingUpdate:
-      maxSurge:  {{ ui.strategy.rollingUpdate.maxSurge | default("25%")}}
-      maxUnavailable: {{ ui.strategy.rollingUpdate.maxUnavailable | default("25%")}}
+      maxSurge:  {{ combined_ui.strategy.rollingUpdate.maxSurge | default("25%")}}
+      maxUnavailable: {{ combined_ui.strategy.rollingUpdate.maxUnavailable | default("25%")}}
 {% endif %}
 {% endif %}
   selector:
@@ -33,17 +33,17 @@ spec:
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-ui'
     spec:
-{% if ui.node_selector is defined %}
+{% if combined_ui.node_selector is defined %}
       nodeSelector:
-        {{ ui.node_selector | indent(width=8) }}
+        {{ combined_ui.node_selector | indent(width=8) }}
 {% endif %}
-{% if ui.tolerations is defined %}
+{% if combined_ui.tolerations is defined %}
       tolerations:
-        {{ ui.tolerations | indent(width=8) }}
+        {{ combined_ui.tolerations | indent(width=8) }}
 {% endif %}
-{% if ui.topology_spread_constraints is defined %} %}
+{% if combined_ui.topology_spread_constraints is defined %} %}
       topologySpreadConstraints:
-        {{ ui.topology_spread_constraints | indent(width=8) }}
+        {{ combined_ui.topology_spread_constraints | indent(width=8) }}
 {% endif %}
       containers:
       - name: eda-ui
@@ -51,8 +51,8 @@ spec:
         imagePullPolicy: '{{ image_pull_policy }}'
         ports:
         - containerPort: 8080
-{% if ui.resource_requirements is defined %}
-        resources: {{ ui.resource_requirements }}
+{% if combined_ui.resource_requirements is defined %}
+        resources: {{ combined_ui.resource_requirements }}
 {% endif %}
         volumeMounts:
           - name: {{ ansible_operator_meta.name }}-nginx-conf

--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -9,16 +9,16 @@ metadata:
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
     app.kubernetes.io/component: '{{ deployment_type }}-worker'
 spec:
-  replicas: {{ worker.replicas }}
-{% if worker.strategy is defined %}
+  replicas: {{ combined_worker.replicas }}
+{% if combined_worker.strategy is defined %}
   strategy:
-    type: {{ worker.strategy.type }}
-{% if worker.strategy.type == "Recreate" %}
+    type: {{ combined_worker.strategy.type }}
+{% if combined_worker.strategy.type == "Recreate" %}
     rollingUpdate: null
-{% elif worker.strategy.type == "RollingUpdate" %}
+{% elif combined_worker.strategy.type == "RollingUpdate" %}
     rollingUpdate:
-      maxSurge:  {{ worker.strategy.rollingUpdate.maxSurge | default("25%")}}
-      maxUnavailable: {{ worker.strategy.rollingUpdate.maxUnavailable | default("25%")}}
+      maxSurge:  {{ combined_worker.strategy.rollingUpdate.maxSurge | default("25%")}}
+      maxUnavailable: {{ combined_worker.strategy.rollingUpdate.maxUnavailable | default("25%")}}
 {% endif %}
 {% endif %}
   selector:
@@ -33,17 +33,17 @@ spec:
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-worker'
     spec:
-{% if worker.node_selector is defined %}
+{% if combined_worker.node_selector is defined %}
       nodeSelector:
-        {{ worker.node_selector | indent(width=8) }}
+        {{ combined_worker.node_selector | indent(width=8) }}
 {% endif %}
-{% if worker.tolerations is defined %}
+{% if combined_worker.tolerations is defined %}
       tolerations:
-        {{ worker.tolerations | indent(width=8) }}
+        {{ combined_worker.tolerations | indent(width=8) }}
 {% endif %}
-{% if worker.topology_spread_constraints is defined %} %}
+{% if combined_worker.topology_spread_constraints is defined %} %}
       topologySpreadConstraints:
-        {{ worker.topology_spread_constraints | indent(width=8) }}
+        {{ combined_worker.topology_spread_constraints | indent(width=8) }}
 {% endif %}
       containers:
       - name: eda-worker
@@ -83,7 +83,7 @@ spec:
           value: {{ ansible_operator_meta.name }}-redis-svc
         ports:
         - containerPort: 8000
-{% if worker.resource_requirements is defined %}
-        resources: {{ worker.resource_requirements }}
+{% if combined_worker.resource_requirements is defined %}
+        resources: {{ combined_worker.resource_requirements }}
 {% endif %}
       restartPolicy: Always

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -30,8 +30,8 @@ _postgres_image_version: 13
 
 
 # Assign a preexisting priority class to the postgres pod
-
-database:
+database: {}
+_database:
   replicas: 1
   resource_requirements:
     requests:

--- a/roles/postgres/tasks/combine_defaults.yml
+++ b/roles/postgres/tasks/combine_defaults.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Combine default and custom variables from the CR for each component
+  set_fact:
+    combined_database: "{{ database | combine ( _database ) }}"

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 # Configure PostgreSQL database and required resources
 
+- name: Combine default and custom vars for each component
+  include_tasks: combine_defaults.yml
+
 - name: Determine and set postgres configuration secret and variables
   import_tasks: set_configuration_secret.yml
 

--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -19,7 +19,6 @@ spec:
       app.kubernetes.io/component: 'database'
       app.kubernetes.io/managed-by: 'eda-operator'
   serviceName: '{{ ansible_operator_meta.name }}'
-  replicas: {{ api.replicas }}
   updateStrategy:
     type: RollingUpdate
   template:
@@ -37,23 +36,23 @@ spec:
           type: RuntimeDefault
         capabilities:
           drop: ["ALL"]
-{% if database.priority_class is defined %}
-      priorityClassName: '{{ database.priority_class }}'
+{% if combined_database.priority_class is defined %}
+      priorityClassName: '{{ combined_database.priority_class }}'
 {% endif %}
-{% if database.node_selector %}
+{% if combined_database.node_selector %}
       nodeSelector:
-        {{ database.node_selector | indent(width=8) }}
+        {{ combined_database.node_selector | indent(width=8) }}
 {% endif %}
-{% if database.tolerations %}
+{% if combined_database.tolerations %}
       tolerations:
-        {{ database.tolerations | indent(width=8) }}
+        {{ combined_database.tolerations | indent(width=8) }}
 {% endif %}
       containers:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           name: postgres
-{% if database.postgres_extra_args %}
-          args: {{ database.postgres_extra_args }}
+{% if combined_database.postgres_extra_args %}
+          args: {{ combined_database.postgres_extra_args }}
 {% endif %}
           env:
             # For postgres_image based on rhel8/postgresql-13
@@ -90,7 +89,7 @@ spec:
                   name: '{{ __database_secret }}'
                   key: password
             - name: PGDATA
-              value: '{{ database.postgres_data_path }}'
+              value: '{{ combined_database.postgres_data_path }}'
             - name: POSTGRES_INITDB_ARGS
               value: '{{ postgres_initdb_args }}'
             - name: POSTGRES_HOST_AUTH_METHOD
@@ -100,10 +99,10 @@ spec:
               name: postgres-{{ supported_pg_version }}
           volumeMounts:
             - name: postgres-{{ supported_pg_version }}
-              mountPath: '{{ database.postgres_data_path | dirname }}'
-              subPath: '{{ database.postgres_data_path | dirname | basename }}'
-{% if database.resource_requirements is defined %}
-          resources: {{ database.resource_requirements }}
+              mountPath: '{{ combined_database.postgres_data_path | dirname }}'
+              subPath: '{{ combined_database.postgres_data_path | dirname | basename }}'
+{% if combined_database.resource_requirements is defined %}
+          resources: {{ combined_database.resource_requirements }}
 {% endif %}
   volumeClaimTemplates:
     - metadata:
@@ -112,6 +111,6 @@ spec:
         accessModes:
           - ReadWriteOnce
 {% if postgres_storage_class is defined %}
-        storageClassName: '{{ database.postgres_storage_class }}'
+        storageClassName: '{{ combined_database.postgres_storage_class }}'
 {% endif %}
-        resources: {{ database.storage_requirements }}
+        resources: {{ combined_database.storage_requirements }}

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -6,7 +6,8 @@ deployment_type: eda
 _redis_image: redis
 _redis_image_version: 7
 
-redis:
+redis: {}
+_redis:
   replicas: 1
   resource_requirements:
     requests:

--- a/roles/redis/tasks/combine_defaults.yml
+++ b/roles/redis/tasks/combine_defaults.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Combine default and custom variables from the CR for each component
+  set_fact:
+    combined_redis: "{{ redis | combine(_redis, recursive=True ) }}"

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 # tasks file for EDA
 
+- name: Combine default and custom vars for each component
+  include_tasks: combine_defaults.yml
+
 - name: Set default redis image to be used
   import_tasks: set_images.yml
 

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 spec:
-  replicas: {{ api.replicas }}
+  replicas: {{ combined_redis.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: 'redis'
@@ -29,13 +29,13 @@ spec:
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
-{% if redis.node_selector %}
+{% if combined_redis.node_selector %}
       nodeSelector:
-        {{ redis.node_selector | indent(width=8) }}
+        {{ combined_redis.node_selector | indent(width=8) }}
 {% endif %}
-{% if redis.tolerations %}
-      redis.tolerations:
-        {{ redis.tolerations | indent(width=8) }}
+{% if combined_redis.tolerations %}
+      tolerations:
+        {{ combined_redis.tolerations | indent(width=8) }}
 {% endif %}
       containers:
         - name: redis
@@ -74,8 +74,8 @@ spec:
                 - -i
                 - -c
                 - redis-cli -h 127.0.0.1 -p 6379
-{% if redis.resource_requirements is defined %}
-          resources: {{ redis.resource_requirements }}
+{% if combined_redis.resource_requirements is defined %}
+          resources: {{ combined_redis.resource_requirements }}
 {% endif %}
       volumes:
         - name: {{ ansible_operator_meta.name }}-redis-data


### PR DESCRIPTION
Currently, if you create an EDA CR using the OLM UI without modification, it will look like this:

```
apiVersion: eda.ansible.com/v1alpha1
kind: EDA
metadata:
  name: eda-demo
spec:
  route_tls_termination_mechanism: Edge
  service_type: ClusterIP
  ingress_type: Route
  loadbalancer_port: 80
  no_log: false
  image_pull_policy: IfNotPresent
  ui_image_version: dev
  api_image_version: dev
  ui_image: quay.io/chadams/eda-ui
  ui:
    replicas: 1
  set_self_labels: true
  api_image: quay.io/chadams/eda-server
  api:
    replicas: 1
  redis:
    replicas: 1
  admin_user: admin
  loadbalancer_protocol: http
  worker:
    replicas: 1
```

When applied, this will fail because `redis:` will overwrite things like `redis.node_selector`, etc, and the defaults/main.yml values won't be used. 


This PR proposes a potential solution where the user-defined settings (`redis`) get merged with the defaults (`_redis`) to form a combined dictionary: `combined_redis`.  

-----------------------
We should investigate if setting defaults in the CSV/CRD metadata is enough.  That could be another viable approach.  