### PR TITLE
Set a default for set_self_labels param

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -12,3 +12,7 @@ additional_labels: []
 # service_account_annotations: |
 #   eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
 service_account_annotations: ''
+
+# This should be true if using the operator loop.
+# Set to false to run a role locally for testing.
+set_self_labels: true


### PR DESCRIPTION
Currently, if `set_self_labels` is not set on the EDA  CR, then the operator will fail on this task.  We should make it possible for the user to deploy with all the defaults and end up with a green deployment.  

```
TASK [Patching labels to EDA resource] ********************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'set_self_labels | bool' failed. The error was: error while evaluating conditional (set_self_labels | bool): 'set_self_labels' is undefined\n\nThe error appears to be in '/opt/ansible/roles/common/tasks/patch_labels.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Patching labels to EDA resource\n ^ here\n"}
```