### PR TITLE
Name operator container eda-manager instead of manager for uniqueness

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -48,7 +48,7 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
-      - name: manager
+      - name: eda-manager
         args:
         - "--health-probe-bind-address=:6789"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -7,4 +7,4 @@ spec:
   template:
     spec:
       containers:
-      - name: manager
+      - name: eda-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,7 +5,7 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
-    app.kubernetes.io/component: manager
+    app.kubernetes.io/component: eda-manager
     app.kubernetes.io/created-by: eda-server-operator
     app.kubernetes.io/part-of: eda-server-operator
     app.kubernetes.io/managed-by: kustomize
@@ -20,7 +20,7 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: manager
+    app.kubernetes.io/component: eda-manager
     app.kubernetes.io/created-by: eda-server-operator
     app.kubernetes.io/part-of: eda-server-operator
     app.kubernetes.io/managed-by: kustomize
@@ -32,7 +32,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: eda-manager
       labels:
         control-plane: controller-manager
     spec:
@@ -66,7 +66,7 @@ spec:
         - --leader-election-id=eda-server-operator
         image: controller:latest
         imagePullPolicy: IfNotPresent
-        name: manager
+        name: eda-manager
         env:
         - name: ANSIBLE_GATHERING
           value: explicit

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: eda-manager-role
 rules:
   ##
   ## Base operator rules

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -3,16 +3,16 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/instance: eda-manager-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: eda-server-operator
     app.kubernetes.io/part-of: eda-server-operator
     app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
+  name: eda-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: eda-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/config/testing/debug_logs_patch.yaml
+++ b/config/testing/debug_logs_patch.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: eda-manager
           env:
           - name: ANSIBLE_DEBUG_LOGS
             value: "TRUE"

--- a/config/testing/manager_image.yaml
+++ b/config/testing/manager_image.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: eda-manager
           image: testing

--- a/config/testing/pull_policy/Always.yaml
+++ b/config/testing/pull_policy/Always.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: eda-manager
           imagePullPolicy: Always

--- a/config/testing/pull_policy/IfNotPresent.yaml
+++ b/config/testing/pull_policy/IfNotPresent.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: eda-manager
           imagePullPolicy: IfNotPresent

--- a/config/testing/pull_policy/Never.yaml
+++ b/config/testing/pull_policy/Never.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - name: manager
+        - name: eda-manager
           imagePullPolicy: Never

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -36,7 +36,7 @@
           k8s_log:
             name: '{{ item.metadata.name }}'
             namespace: '{{ namespace }}'
-            container: manager
+            container: eda-manager
           loop: "{{ q('k8s', api_version='v1', kind='Pod', namespace=namespace, label_selector=ctrl_label) }}"
           register: debug_logs
 


### PR DESCRIPTION
Similar to these changes for awx-operator:
* https://github.com/ansible/awx-operator/pull/617/files

This was needed for this operator, awx-operator and hub operators to coexist under one meta operator.  