### PR TITLE
Add activation rules for SA for worker container

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -105,6 +105,23 @@ rules:
     verbs:
       - create
       - get
+
+  ## Rule for Operator SA so it can grant them to worker deployment SA
+  - apiGroups:
+      - ""
+      - batch
+      - extensions
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
   ##
   ## Rules for eda.ansible.com/v1alpha1, Kind: EDA
   ##

--- a/roles/common/templates/service_account.yaml.j2
+++ b/roles/common/templates/service_account.yaml.j2
@@ -20,17 +20,11 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods"]
+  resources: ["pods", "pods/log", "jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["pods/log"]
-  verbs: ["get"]
-- apiGroups: [""]
-  resources: ["pods/attach"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "create", "delete"]
 
 ---
 kind: RoleBinding

--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -33,6 +33,7 @@ spec:
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-worker'
     spec:
+      serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if combined_worker.node_selector is defined %}
       nodeSelector:
         {{ combined_worker.node_selector | indent(width=8) }}

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -28,7 +28,6 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-      serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if combined_redis.node_selector %}
       nodeSelector:
         {{ combined_redis.node_selector | indent(width=8) }}


### PR DESCRIPTION
* Adds only the needed permission rules to the Worker deployment's ServiceAccount
* Adds those same rules to the operator SA so that it has the ability to grant them to the worker SA
* Removes the SA from the Redis deployment so that the default is used