### PR TITLE
Add defaults for EDA sample yaml

### DIFF
--- a/config/samples/eda_v1alpha1_eda.yaml
+++ b/config/samples/eda_v1alpha1_eda.yaml
@@ -9,4 +9,39 @@ metadata:
     app.kubernetes.io/created-by: eda-server-operator
   name: eda-sample
 spec:
-  # TODO(user): Add fields here
+  no_log: true
+  image_pull_policy: IfNotPresent
+  service_type: ClusterIP
+  ingress_type: Route
+  api:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  worker:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  ui:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  redis:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  database:
+    resource_requirements:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    storage_requirements:
+      requests:
+        storage: 20Gi

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -29,7 +29,6 @@ _postgres_image_version: 13
 # Assign a preexisting priority class to the postgres pod
 database: {}
 _database:
-  replicas: 1
   resource_requirements:
     requests:
       cpu: 200m


### PR DESCRIPTION
This example file is used to pre-populate defaults in the UI form when using Openshift's built-in OperatorHub interface or OKD.