### PR TITLE
Remove seccomprofile from securityContext

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,8 +58,6 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       containers:
       - args:
         - --leader-elect

--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -33,8 +33,6 @@ spec:
     spec:
       securityContext:
         allowPrivilegeEscalation: false
-        seccompProfile:
-          type: RuntimeDefault
         capabilities:
           drop: ["ALL"]
 {% if database.priority_class is defined %}


### PR DESCRIPTION
This causes issues on clusters < 4.11 , per:

https://github.com/operator-framework/operator-sdk/issues/6038