### PR TITLE
Fix typo in backup_name assertion

### DIFF
--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -3,7 +3,7 @@
   assert:
     that:
       - backup_name is defined
-      - backup_name | lenth
+      - backup_name | length
     fail_msg: "When the backup_source is 'CR' (custom EDABackup resource), backup_name must be set."
   when: backup_source == "CR"
 


### PR DESCRIPTION
Currently seeing this error:

```
TASK [Fail if backup_name is not set] ********************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'backup_name | lenth' failed. The error was: template error while templating string: no filter named 'lenth'. String: {% if backup_name | lenth %} True {% else %} False {% endif %}"}
```