### PR TITLE
Use Role instead of ClusterRole for truly namespace-scoped operator

### DIFF
--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/name: role
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: eda-server-operator

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/name: role
     app.kubernetes.io/instance: proxy-role
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: eda-server-operator

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: proxy-rolebinding
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: eda-server-operator
@@ -11,7 +11,7 @@ metadata:
   name: proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: proxy-role
 subjects:
 - kind: ServiceAccount

--- a/config/rbac/eda_editor_role.yaml
+++ b/config/rbac/eda_editor_role.yaml
@@ -1,9 +1,9 @@
 # permissions for end users to edit edas.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/name: role
     app.kubernetes.io/instance: eda-editor-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: eda-server-operator

--- a/config/rbac/eda_viewer_role.yaml
+++ b/config/rbac/eda_viewer_role.yaml
@@ -1,9 +1,9 @@
 # permissions for end users to view edas.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/name: role
     app.kubernetes.io/instance: eda-viewer-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: eda-server-operator

--- a/config/rbac/edabackup_editor_role.yaml
+++ b/config/rbac/edabackup_editor_role.yaml
@@ -1,6 +1,6 @@
 # permissions for end users to edit edabackups.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: edabackup-editor-role
 rules:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: eda-manager-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: eda-server-operator


### PR DESCRIPTION
Currently, if you only have access to one namespace and try to run `make deploy` it will fail because it can't create the kube-rbac-proxy clusterroles.  A user who only has access to a single namespace on a cluster should be able to install our "namespace-scoped" cluster.  Error:

```
Error from server (Forbidden): error when retrieving current configuration of:
Resource: "rbac.authorization.k8s.io/v1, Resource=clusterrolebindings", GroupVersionKind: "rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding"
Name: "eda-server-operator-proxy-rolebinding", Namespace: ""
from server for: "STDIN": clusterrolebindings.rbac.authorization.k8s.io "eda-server-operator-proxy-rolebinding" is forbidden: User "rhn-gps-jpisciot" cannot get resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope
```