### PR TITLE
Change API image tag from latest to main

### DIFF
--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -8,7 +8,7 @@ api_version: '{{ deployment_type }}.ansible.com/v1alpha1'
 no_log: true
 
 _api_image: quay.io/ansible/eda-server
-_api_image_version: latest
+_api_image_version: main
 
 _ui_image: quay.io/ansible/eda-ui
 _ui_image_version: latest


### PR DESCRIPTION
It seems the eda-server image actually uses the floating tag `main`, not `latest`.  This change aligns with that.  

* https://quay.io/repository/ansible/eda-server

cc @ddonahue007 @rcarrillocruz for awareness