### PR TITLE
Inject image pull secrets into deployment templates correctly and set defaults

### DIFF
--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -7,6 +7,9 @@ api_version: '{{ deployment_type }}.ansible.com/v1alpha1'
 
 no_log: true
 
+image_pull_policy: IfNotPresent
+image_pull_secrets: []
+
 _api_image: quay.io/ansible/eda-server
 _api_image_version: main
 

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -33,7 +33,7 @@ spec:
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-api'
     spec:
-{% elif image_pull_secrets | length > 0 %}
+{% if image_pull_secrets | length > 0 %}
       imagePullSecrets:
 {% for secret in image_pull_secrets %}
         - name: {{ secret }}

--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -33,7 +33,7 @@ spec:
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-ui'
     spec:
-{% elif image_pull_secrets | length > 0 %}
+{% if image_pull_secrets | length > 0 %}
       imagePullSecrets:
 {% for secret in image_pull_secrets %}
         - name: {{ secret }}

--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/component: '{{ deployment_type }}-worker'
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
-{% elif image_pull_secrets | length > 0 %}
+{% if image_pull_secrets | length > 0 %}
       imagePullSecrets:
 {% for secret in image_pull_secrets %}
         - name: {{ secret }}

--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -34,7 +34,7 @@ spec:
         allowPrivilegeEscalation: false
         capabilities:
           drop: ["ALL"]
-{% elif image_pull_secrets | length > 0 %}
+{% if image_pull_secrets | length > 0 %}
       imagePullSecrets:
 {% for secret in image_pull_secrets %}
         - name: {{ secret }}

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -3,6 +3,9 @@
 
 deployment_type: eda
 
+image_pull_policy: IfNotPresent
+image_pull_secrets: []
+
 _redis_image: redis
 _redis_image_version: 7
 

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
     spec:
-{% elif image_pull_secrets | length > 0 %}
+{% if image_pull_secrets | length > 0 %}
       imagePullSecrets:
 {% for secret in image_pull_secrets %}
         - name: {{ secret }}


### PR DESCRIPTION
Follow-up fix for https://github.com/ansible/eda-server-operator/pull/40

This also adds to default image_pull_secrets value in `roles/*/defaults/main.yml`.

cc @rcarrillocruz 
cc @ddonahue007 when trying this out, since the eda-server image is private atm, you'll need to create a pull secret and specify it on the EDA spec.  


#### Usage

You can create a pull secret from your local ~/.docker/config.json file by:

```
$ docker login quay.io

$ kubectl create secret generic gitlab-pull-cred --from-file=.dockerconfigjson=~/.docker/config.json --type=kubernetes.io/dockerconfigjson
```

Here is an example of an EDA CR that specifies a pull secret:


```
apiVersion: eda.ansible.com/v1alpha1
kind: EDA
metadata:
  name: eda-demo
spec:
  route_tls_termination_mechanism: Edge
  service_type: ClusterIP
  ingress_type: Route
  loadbalancer_port: 80
  no_log: false
  image_pull_policy: Always
  ui_image: quay.io/ansible/eda-ui
  ui_image_version: latest
  api_image: quay.io/ansible/eda-server
  api_image_version: main
  image_pull_secrets:
    - chadams-pull-secret

```
