### PR TITLE
Increase default worker replicas to 2

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -752,7 +752,7 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 1
+                    default: 2
                     description: 'Size is the size of number of eda-worker replicas.
                       Default: 1'
                     format: int32

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -36,7 +36,7 @@ _api:
 
 worker: {}
 _worker:
-  replicas: 1
+  replicas: 2
   resource_requirements:
     requests:
       cpu: 200m


### PR DESCRIPTION
Default to 2 replicas for worker deployment to better handle concurrency issues.  Also, this will help us test concurrency issues.