### PR TITLE
Remove unnecessary waits that were added during debugging

### DIFF
--- a/roles/eda/tasks/admin_password_configuration.yml
+++ b/roles/eda/tasks/admin_password_configuration.yml
@@ -26,7 +26,6 @@
       kubernetes.core.k8s:
         apply: true
         definition: "{{ lookup('template', 'secrets/admin_password_secret.yaml.j2') }}"
-        wait: yes
       no_log: "{{ no_log }}"
 
     - name: Read admin password secret

--- a/roles/eda/tasks/db_fields_encryption_configuration.yml
+++ b/roles/eda/tasks/db_fields_encryption_configuration.yml
@@ -26,7 +26,6 @@
       kubernetes.core.k8s:
         apply: true
         definition: "{{ lookup('template', 'secrets/db_fields_encryption.yaml.j2') }}"
-        wait: yes
       no_log: "{{ no_log }}"
 
     - name: Read DB fields encryption secret

--- a/roles/postgres/tasks/set_configuration_secret.yml
+++ b/roles/postgres/tasks/set_configuration_secret.yml
@@ -31,7 +31,6 @@
       k8s:
         apply: true
         definition: "{{ lookup('template', 'postgres.secret.yaml.j2') }}"
-        wait: yes
       no_log: "{{ no_log }}"
 
     - name: Read Database Configuration


### PR DESCRIPTION
These waits were added while debugging a failed read on the generated secrets.  The error ended up actually being fixed by this line:
* https://github.com/ansible/eda-server-operator/pull/50/files#diff-45879962d939763258c8268e10a38e869af270cb3d7f420bfa3ea279968f4894R36

Turns out the waits were not needed.  