### PR TITLE
Revert "Set VERSION to stable until first release"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= stable
+VERSION ?= 0.0.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")


### PR DESCRIPTION
This will make catalog builds fail, it needs to be an NVR.  This reverts commit ff9f1412ffb9309459c8fd24f2c49371268fd849.

Instead, I will just cut the first release as 0.0.1 for now.  