### PR TITLE
Add doc note about release tags in kustomize install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ This operator is meant to provide a more Kubernetes-native installation method f
 
 ## Installing the Operator
 
-1. Clone the awx-resource-operator
+1. Clone the eda-server-operator
 
 ```
-git clone git@github.com:ansible/awx-resource-operator.git
+git clone git@github.com:ansible/eda-server-operator.git
 ```
 
 2. Log in to your K8s or Openshift cluster.
@@ -36,7 +36,7 @@ kubectl login <cluster-url>
 3. Run the `make deploy` target
 
 ```
-NAMESPACE=awx IMG=quay.io/ansible/eda-server-operator:latest make deploy
+NAMESPACE=eda IMG=quay.io/ansible/eda-server-operator:latest make deploy
 ```
 
 > **Note** You can use kustomize directly to dynamically modify things like the operator deployment at deploy time.  For directions on how to install this way, see the [kustomize install docs](./docs/kustomize-install.md).

--- a/docs/kustomize-install.md
+++ b/docs/kustomize-install.md
@@ -3,7 +3,7 @@
 Some folks may prefer to install the EDA Server Operator using kustomize directly with a personalized kustomize file.  This allows you to easily modify configuration files including the operator's manager deployment itself. To do so, follow the instructions below.  
 
 
-1. Create a `kustomization.yaml` file with the the following contents:
+1. Create a `kustomization.yaml` file with the the following contents. Be sure to change `newTag` to the latest released tag, or the tag you would like to deploy.
 
 ```
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -14,7 +14,7 @@ resources:
 # Set the image tags to match the git version from above
 images:
   - name: quay.io/ansible/eda-server-operator
-    newTag: stable
+    newTag: 0.0.1
 
 # Specify a custom namespace in which to install EDA
 namespace: eda


### PR DESCRIPTION
The first release tag has been cut, we should reference it in the kustomize-install.md.  

* Also fixes some s/awx/eda/g style bugs in the docs.  