### PR TITLE
Add --with-scheduler flag to worker entrypoint

### DIFF
--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -59,7 +59,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - aap-eda-manage rqworker --worker-class aap_eda.core.tasking.Worker
+        - aap-eda-manage rqworker --with-scheduler --worker-class aap_eda.core.tasking.Worker
         env:
         - name: EDA_DB_HOST
           valueFrom:


### PR DESCRIPTION
Associated aap-eda PR:
* https://github.com/ansible/aap-eda/pull/213

Adds the `--with-scheduler` flag to the worker container's entrypoint.  