### PR TITLE
Remove host specification assertion

### DIFF
--- a/roles/common/tasks/pre-checks.yml
+++ b/roles/common/tasks/pre-checks.yml
@@ -2,6 +2,6 @@
 - name: Fail if automation_host_connection_secrets is not (only one should be set)
   assert:
     that:
-      - automation_host_connection_secrets is defined
-      - automation_host_connection_secrets | length == 1
-    fail_msg: "Please set a single automation server connection secret to be used via the automation_host_connection_secrets parameter." #noqa
+      - automation_host_connection_secrets | length <= 1
+    fail_msg: "Please only set a single automation server connection secret to be used via the automation_host_connection_secrets parameter. For the time being, only specifying one is supported." #noqa
+  when: automation_host_connection_secrets is defined


### PR DESCRIPTION
We should only fail if more than one host is specified for `automation_host_connection_secrets`.  And that is only a temporary measure.

If we remove the assertion all together, then it will just pick the first secret in the list.  I could go either way.  