### PR TITLE
Add rules needed for creating secrets and ingresses for activation pods

### DIFF
--- a/roles/common/templates/service_account.yaml.j2
+++ b/roles/common/templates/service_account.yaml.j2
@@ -20,10 +20,13 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods", "pods/log", "jobs"]
-  verbs: ["get", "list", "watch"]
+  resources: ["pods", "pods/log", "jobs", "secrets", "services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---


### PR DESCRIPTION
Permission rules needed on the EDA Service Account in order to create the pull secret and clean it up, as well as create and configure the ingress needed for certain rulesetActivation pods.  

Follow-up for:
* https://github.com/ansible/eda-server-operator/pull/61