### PR TITLE
Set ssl_verify as an advanced setting for now

### DIFF
--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -185,6 +185,7 @@ spec:
         path: automation_server_ssl_verify
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Admin Account Username
         path: admin_user
         x-descriptors:


### PR DESCRIPTION
Until we have documentation around how to configure the SSL certs, the default should be ssl_verify so this works out of the box.  

To configure this for ssl-verification to work, the user would have to:
1. Build their own Decision Environment and stuff the certs needed for Controller in /etc/pki/ca-trust/source/anchors 
2. Run `update-ca-trust`
3. Specify that DE to be used for the RulebookActivation

We may want to consider instead having the user specify the certs in the UI and we configmap them into the container for the user.