### PR TITLE
Add ephemeral media dir mount & fix settings mount

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -120,6 +120,14 @@ spec:
           failureThreshold: 1
           periodSeconds: 10
           initialDelaySeconds: 30
+{% if combined_api.resource_requirements is defined %}
+        resources: {{ combined_api.resource_requirements }}
+{% endif %}
+        volumeMounts:
+          - name: {{ ansible_operator_meta.name }}-settings
+            mountPath: /app/src/src/aap_eda/settings/default.py
+            subPath: default.py
+            readOnly: true
       - name: daphne
         image: {{ _api_image }}
         imagePullPolicy: '{{ image_pull_policy }}'
@@ -172,7 +180,6 @@ spec:
           value: 'ws://{{ websocket_server_name }}:8001'
         - name: EDA_WEBSOCKET_SSL_VERIFY
           value: '{{ websocket_ssl_verify }}'
-
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}

--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -106,4 +106,20 @@ spec:
 {% if combined_worker.resource_requirements is defined %}
         resources: {{ combined_worker.resource_requirements }}
 {% endif %}
+        volumeMounts:
+          - name: {{ ansible_operator_meta.name }}-settings
+            mountPath: /app/src/src/aap_eda/settings/default.py
+            subPath: default.py
+            readOnly: true
+          - name: "{{ ansible_operator_meta.name }}-media-data"
+            mountPath: "{{ media_dir }}"
       restartPolicy: Always
+      volumes:
+        - name: {{ ansible_operator_meta.name }}-settings
+          configMap:
+            name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+            items:
+              - key: settings
+                path: default.py
+        - name: {{ ansible_operator_meta.name }}-media-data
+          emptyDir: {}

--- a/roles/eda/vars/main.yml
+++ b/roles/eda/vars/main.yml
@@ -2,3 +2,4 @@
 # vars file for EDA
 
 websocket_server_name: "{{ ansible_operator_meta.name }}-daphne"
+media_dir: /var/lib/eda/files


### PR DESCRIPTION
We need to mount the media dir as an ephemeral emptyDir so that when replicas > 1 for the worker deployment, they use the same dir contents.  

The settings mount was inadvertently removed from the api container when the daphne pod was added.  This is the weirdness we saw with the deployment_type settings inexplicably no longer being set @ddonahue007 @rcarrillocruz 