### PR TITLE
Fix dbFieldsEncryptionSecret status name

### DIFF
--- a/roles/eda/tasks/update_status.yml
+++ b/roles/eda/tasks/update_status.yml
@@ -33,7 +33,7 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
-      dbEncryptionFieldsSecret: "{{ db_fields_encryption_secret_name }}"
+      dbFieldsEncryptionSecret: "{{ db_fields_encryption_secret_name }}"
 
 - block:
     - name: Retrieve instance version


### PR DESCRIPTION
 - This was causing backups to fail because the status expected was named differently from the status created.