### PR TITLE
Add GHA to build and push main branch operator image automatically

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -1,0 +1,27 @@
+---
+
+name: Build Main Branch Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Push main image
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Image
+        run: |
+          IMG=eda-server-operator:devel make docker-build
+
+      - name: Push To Quay
+        uses: redhat-actions/push-to-registry@v2.1.1
+        with:
+          image: eda-server-operator
+          tags: main
+          registry: quay.io/ansible/
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
Resolves: https://github.com/ansible/eda-server-operator/issues/67

This adds a workflow to build the operator image from the `main` branch and push it to quay.io so that users can try out the latest operator without having to build their own image and push to their own registry.  