### PR TITLE
Add note about using the main image tag for most recent code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ kubectl login <cluster-url>
 ```
 NAMESPACE=eda IMG=quay.io/ansible/eda-server-operator:latest make deploy
 ```
+> **Note** The `latest` tag is the latest _released_ (tagged) version. The deploy with the latest code in `main` branch, use `IMG=quay.io/ansible/eda-server-operator:main` instead.
 
 > **Note** You can use kustomize directly to dynamically modify things like the operator deployment at deploy time.  For directions on how to install this way, see the [kustomize install docs](./docs/kustomize-install.md).
 
@@ -73,8 +74,6 @@ spec:
   image_pull_secrets:
     - pull_secret_name
 ```
-
-
 
 
 ### Advanced Configuration


### PR DESCRIPTION
Add a doc note that you can now deploy from the `main` branch.

The eda-server-operator:main image now automatically gets built and pushed whenever new commits land in the main branch.
* https://github.com/ansible/eda-server-operator/issues/67

What is means, is you can now install the latest in the main branch without needing to build the operator image yourself.
To do so, just run this in the top level of your local eda-server-operator clone:

```
NAMESPACE=your-namespace IMG=quay.io/ansible/eda-server-operator:main make deploy
```
