### PR TITLE
Change pull secret doc example to use expected secret name

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ docker login quay.io -u <user> -p <token>
 2. Then, create a k8s secret from your .docker/config.json file.
 
 ```bash
-kubectl create secret generic quay-pull-cred \
+kubectl create secret generic redhat-operators-pull-secret \
   --from-file=.dockerconfigjson=.docker/config.json \
   --type=kubernetes.io/dockerconfigjson
 ```
@@ -135,5 +135,5 @@ kubectl create secret generic quay-pull-cred \
 ---
 spec:
   image_pull_secrets:
-    - quay-pull-cred
+    - redhat-operators-pull-secret
 ```


### PR DESCRIPTION
The operator deployment will look for a pull secret named `redhat-operators-pull-secret` if it is present in the namespace, and it will use it when pulling the operator image if present.  

Therefore, we should make our example use this name, at least until the quay.io repo is made public.  