### PR TITLE
Rename api and web image variables for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ Example of customization could be:
 ---
 spec:
   ...
-  api_image: myorg/my-custom-eda
-  api_image_version: latest
-  ui_image: myorg/my-custom-eda
-  ui_image_version: latest
+  image: myorg/my-custom-eda
+  image_version: latest
+  image_web: myorg/my-custom-eda
+  image_web_version: latest
   image_pull_policy: Always
   image_pull_secrets:
     - pull_secret_name

--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -65,16 +65,16 @@ spec:
                 description: Configure no_log for no log tasks
                 type: boolean
                 default: true
-              api_image:
+              image:
                 description: Registry path to API container image to use
                 type: string
-              api_image_version:
+              image_version:
                 description: API container image tag or version to use
                 type: string
-              ui_image:
+              image_web:
                 description: Registry path to UI container image to use
                 type: string
-              ui_image_version:
+              image_web_version:
                 description: UI container image tag or version to use
                 type: string
               redis_image:

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -289,22 +289,22 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: API Image
-        path: api_image
+        path: image
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: API Image Version
-        path: api_image_version
+        path: image_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: UI Image
-        path: ui_image
+        path: image_web
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: UI Image Version
-        path: ui_image_version
+        path: image_web_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/roles/common/templates/labels/version.yaml.j2
+++ b/roles/common/templates/labels/version.yaml.j2
@@ -1,1 +1,1 @@
-app.kubernetes.io/version: '{{ _api_image.split(':')[-1] | truncate(63, True, '', 0) }}'
+app.kubernetes.io/version: '{{ _image.split(':')[-1] | truncate(63, True, '', 0) }}'

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -10,11 +10,11 @@ no_log: true
 image_pull_policy: IfNotPresent
 image_pull_secrets: []
 
-_api_image: quay.io/ansible/eda-server
-_api_image_version: main
+_image: quay.io/ansible/eda-server
+_image_version: main
 
-_ui_image: quay.io/ansible/eda-ui
-_ui_image_version: latest
+_image_web: quay.io/ansible/eda-ui
+_image_web_version: latest
 
 # Add a nodeSelector for the EDA pods. It must match a node's labels for the pod
 # to be scheduled on that node. Specify as literal block. E.g.:

--- a/roles/eda/tasks/set_images.yml
+++ b/roles/eda/tasks/set_images.yml
@@ -3,37 +3,37 @@
 # API Image
 - name: Set default eda api container image
   set_fact:
-    _default_api_image: "{{ _api_image }}:{{ _api_image_version }}"
+    _default_image: "{{ _image }}:{{ _image_version }}"
 
 - name: Set user provided image
   set_fact:
-    _custom_api_image: "{{ api_image }}:{{ api_image_version }}"
+    _custom_image: "{{ image }}:{{ image_version }}"
   when:
-    - api_image | default([]) | length
-    - api_image_version is defined or api_image_version != ''
+    - image | default([]) | length
+    - image_version is defined or image_version != ''
 
 - name: Set image URL
   set_fact:
-    _api_image: >-
-      {{ _custom_api_image |
-         default(lookup('env', 'RELATED_IMAGE_EDA_API')) |
-         default(_default_api_image, true) }}
+    _image: >-
+      {{ _custom_image |
+         default(lookup('env', 'RELATED_IMAGE_EDA')) |
+         default(_default_image, true) }}
 
 # UI Image
 - name: Set default eda ui container image
   set_fact:
-    _default_ui_image: "{{ _ui_image }}:{{ _ui_image_version }}"
+    _default_image_web: "{{ _image_web }}:{{ _image_web_version }}"
 
 - name: Set user provided image
   set_fact:
-    _custom_ui_image: "{{ ui_image }}:{{ ui_image_version }}"
+    _custom_image_web: "{{ image_web }}:{{ image_web_version }}"
   when:
-    - ui_image | default([]) | length
-    - ui_image_version is defined or ui_image_version != ''
+    - image_web | default([]) | length
+    - image_web_version is defined or image_web_version != ''
 
 - name: Set image URL
   set_fact:
-    _ui_image: >-
-      {{ _custom_ui_image |
+    _image_web: >-
+      {{ _custom_image_web |
          default(lookup('env', 'RELATED_IMAGE_EDA_UI')) |
-         default(_default_ui_image, true) }}
+         default(_default_image_web, true) }}

--- a/roles/eda/tasks/update_status.yml
+++ b/roles/eda/tasks/update_status.yml
@@ -65,7 +65,7 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
-      image: "{{ _api_image }}"
+      image: "{{ _image }}"
 
 - block:
     - name: Retrieve route URL

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -53,7 +53,7 @@ spec:
 {% endif %}
       containers:
       - name: eda-api
-        image: {{ _api_image }}
+        image: {{ _image }}
         imagePullPolicy: '{{ image_pull_policy }}'
         args:
         - /bin/bash
@@ -132,7 +132,7 @@ spec:
             subPath: default.py
             readOnly: true
       - name: daphne
-        image: {{ _api_image }}
+        image: {{ _image }}
         imagePullPolicy: '{{ image_pull_policy }}'
         args:
         - /bin/bash

--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -53,7 +53,7 @@ spec:
 {% endif %}
       containers:
       - name: eda-ui
-        image: {{ _ui_image }}
+        image: {{ _image_web }}
         imagePullPolicy: '{{ image_pull_policy }}'
         ports:
         - containerPort: 8080

--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -54,7 +54,7 @@ spec:
 {% endif %}
       containers:
       - name: eda-worker
-        image: {{ _api_image }}
+        image: {{ _image }}
         imagePullPolicy: '{{ image_pull_policy }}'
         args:
         - /bin/bash


### PR DESCRIPTION
To make the eda-server-operator more consistent with the other operators in the community (awx-operator, pulp-operator), we are changing the image var names to:
* `image` - API & Worker image
* `image_web` - UI image

Same goes for the `*_version` variables.  
I also changed `RELATED_IMAGE_EDA_API` --> `RELATED_IMAGE_EDA`