### PR TITLE
Add OPERATOR_VERSION env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/operator-framework/ansible-operator:v1.27.0
 
+ARG OPERATOR_VERSION
+ENV OPERATOR_VERSION=${OPERATOR_VERSION}
+
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ run: ansible-operator ## Run against the configured Kubernetes cluster in ~/.kub
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build $(BUILD_ARGS) -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
Add the OPERATOR_VERSION env var during the operator image build and enable configuring it via the make target.  This env var is used when setting the operator_version annotation on certain pods.  

Currently, it is not set, and shows as `operator_version=`