### PR TITLE
Add back extra_settings templating & add new EDA resource settings

### DIFF
--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -269,11 +269,22 @@ data:
         "RULEBOOK_LIVENESS_TIMEOUT_SECONDS", 610
     )
 
+    ACTIVATION_POD_RESOURCE_REQUESTS = settings.get(
+        "ACTIVATION_POD_RESOURCE_REQUESTS", {"cpu": "50m", "memory": "100Mi"}
+    )
+    ACTIVATION_POD_RESOURCE_LIMITS = settings.get(
+        "ACTIVATION_POD_RESOURCE_LIMITS", {}
+    )
+
     # ---------------------------------------------------------
     # RULEBOOK ENGINE LOG LEVEL
     # ---------------------------------------------------------
     ANSIBLE_RULEBOOK_LOG_LEVEL = settings.get("ANSIBLE_RULEBOOK_LOG_LEVEL", "-v")
     ANSIBLE_RULEBOOK_FLUSH_AFTER = settings.get("ANSIBLE_RULEBOOK_FLUSH_AFTER", 1)
+
+{% for item in extra_settings | default([]) %}
+    {{ item.setting }} = {{ item.value }}
+{% endfor %}
 
   nginx_conf: |
     events {


### PR DESCRIPTION
The template logic that made the extra_settings feature work was mistakenly removed in:
* https://github.com/ansible/eda-server-operator/commit/73628532863088c47a848e7d1e29d3f78e8e3d50

This also adds in recently added default.py settings to the configmap.  