### PR TITLE
Increase default worker count to 5 to enable more activations ootb

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -751,7 +751,7 @@ spec:
                 type: object
               worker:
                 default:
-                  replicas: 1
+                  replicas: 5
                 description: Defines desired state of eda-worker resources
                 properties:
                   node_selector:

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -38,7 +38,7 @@ _api:
 
 worker: {}
 _worker:
-  replicas: 2
+  replicas: 5
   resource_requirements:
     requests:
       cpu: 200m


### PR DESCRIPTION
Currently, one limitation of the EDA application is that it can only have as many concurrent activations and project syncs as it has worker pods. To run more activations, you can scale up the worker deployment by setting replicas on the EDA spec.

This PR adds a doc note and sets the default replicas to 5. 