### PR TITLE
Preferentially use user-specifiecd values when combining deployment params

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ spec:
 docker login quay.io -u <user> -p <token>
 ```
 
-2. Then, create a k8s secret from your .docker/config.json file.
+2. Then, create a k8s secret from your .docker/config.json file. This pull secret should be created in the same namespace you are installing the EDA Operator.
 
 ```bash
 kubectl create secret generic redhat-operators-pull-secret \

--- a/docs/kustomize-install.md
+++ b/docs/kustomize-install.md
@@ -5,7 +5,7 @@ Some folks may prefer to install the EDA Server Operator using kustomize directl
 
 1. Create a `kustomization.yaml` file with the the following contents. Be sure to change `newTag` to the latest released tag, or the tag you would like to deploy.
 
-```
+```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -29,3 +29,22 @@ kustomize build . | kubectl apply -f -
 For more information on how to use kustomize to modify configuration files dynamically, see these docs:
 * Kustomize documentation - https://kustomize.io/
 * Using Kustomize to deploy an ansible-operator - https://sdk.operatorframework.io/docs/building-operators/ansible/tutorial/
+
+
+### Install Latest
+
+It is possible to install the latest available changes from the `main` branch using this approach as well. To do so, you will want a kustomization.yaml file like this:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github.com/ansible/eda-server-operator/config/default
+
+images:
+  - name: quay.io/ansible/eda-server-operator
+    newTag: main
+
+# Specify a custom namespace in which to install EDA
+namespace: eda
+```

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -41,8 +41,8 @@ _worker:
   replicas: 5
   resource_requirements:
     requests:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 25m
+      memory: 64Mi
   node_selector: ''
   tolerations: ''
 

--- a/roles/eda/tasks/combine_defaults.yml
+++ b/roles/eda/tasks/combine_defaults.yml
@@ -2,6 +2,6 @@
 
 - name: Combine default and custom variables from the CR for each component
   set_fact:
-    combined_api: "{{ api | combine ( _api ) }}"
-    combined_ui: "{{ ui | combine ( _ui ) }}"
-    combined_worker: "{{ worker | combine ( _worker ) }}"
+    combined_api: "{{ _api | combine (api, recursive=True ) }}"
+    combined_ui: "{{ _ui | combine (ui, recursive=True) }}"
+    combined_worker: "{{ _worker | combine (worker, recursive=True) }}"

--- a/roles/postgres/tasks/combine_defaults.yml
+++ b/roles/postgres/tasks/combine_defaults.yml
@@ -2,4 +2,4 @@
 
 - name: Combine default and custom variables from the CR for each component
   set_fact:
-    combined_database: "{{ database | combine ( _database ) }}"
+    combined_database: "{{ _database | combine (database, recursive=True) }}"

--- a/roles/redis/tasks/combine_defaults.yml
+++ b/roles/redis/tasks/combine_defaults.yml
@@ -2,4 +2,4 @@
 
 - name: Combine default and custom variables from the CR for each component
   set_fact:
-    combined_redis: "{{ redis | combine(_redis, recursive=True ) }}"
+    combined_redis: "{{ _redis | combine(redis, recursive=True) }}"


### PR DESCRIPTION
* Preferentially use user-specifiecd values when combining deployment params.  The order was wrong previously.  

Now it is correct:
```
 TASK [debug] ******************************** 
ok: [localhost] => {
    "msg": "Defaults: {'replicas': 5, 'resource_requirements': {'requests': {'cpu': '25m', 'memory': '64Mi'}}, 'node_selector': '', 'tolerations': ''}"
}

-------------------------------------------------------------------------------
{"level":"info","ts":1685044551.5659666,"logger":"logging_event_handler","msg":"[playbook debug]","name":"eda-demo","namespace":"eda","gvk":"eda.ansible.com/v1alpha1, Kind=EDA","event_type":"runner_on_ok","job":"7760016390015490040","EventData.TaskArgs":""}

--------------------------- Ansible Task StdOut -------------------------------

 TASK [debug] ******************************** 
ok: [localhost] => {
    "msg": "User Specified: {'replicas': 3, 'resource_requirements': {'requests': {'cpu': '50m', 'memory': '128Mi'}}}"
}

-------------------------------------------------------------------------------
{"level":"info","ts":1685044551.8493264,"logger":"logging_event_handler","msg":"[playbook debug]","name":"eda-demo","namespace":"eda","gvk":"eda.ansible.com/v1alpha1, Kind=EDA","event_type":"runner_on_ok","job":"7760016390015490040","EventData.TaskArgs":""}

--------------------------- Ansible Task StdOut -------------------------------

 TASK [debug] ******************************** 
ok: [localhost] => {
    "msg": "Combined: {'replicas': 3, 'resource_requirements': {'requests': {'cpu': '50m', 'memory': '128Mi'}}, 'node_selector': '', 'tolerations': ''}"
```

* Add a docs not about needing to add the pull secret in the namespace EDA is deployed in. 
* Decrease default worker pod resource_requireiments