### PR TITLE
Lock down websocket path to internal cluster deployments

### DIFF
--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -302,18 +302,6 @@ data:
             server_tokens off;
             root /opt/app-root/ui/eda;
 
-            location ~ ^/api/eda/ws/[0-9a-z-]+ {
-                proxy_pass http://{{ ansible_operator_meta.name }}-daphne:8001;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header X-Forwarded-Port $server_port;
-                proxy_set_header Host $http_host;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-                proxy_http_version 1.1;
-                proxy_set_header Upgrade $http_upgrade;
-                proxy_set_header Connection "Upgrade";
-            }
-
             location ~ ^/api/eda/v[0-9]+/ {
                 proxy_pass http://{{ ansible_operator_meta.name }}-api:8000;
                 proxy_set_header Host $http_host;


### PR DESCRIPTION
This denies external access to the websocket endpoints until TLS is enabled for websockets (wss).  