### PR TITLE
eda: Fix bare variable condition

### DIFF
--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -24,7 +24,7 @@
     wait_condition:
       status: "True"
       type: Complete
-  when: not _eda_api_pod_name
+  when: not _eda_api_pod_name | length
 
 - name: Run Migrations in API pod if available
   kubernetes.core.k8s_exec:
@@ -34,7 +34,7 @@
       aap-eda-manage migrate
   register: _migrations
   changed_when: not "No migrations to apply" in _migrations.stdout
-  when: _eda_api_pod_name
+  when: _eda_api_pod_name | length
 
 - name: Apply ConfigMap resources
   k8s:


### PR DESCRIPTION
After the inital operator execution, the django migration task is executed from the EDA API pod.
However the condition use a string variable without any filter creating an error when the variable isn't empty.

```console
The conditional check '_eda_api_pod_name' failed. The error was: Invalid conditional detected: invalid syntax (<unknown>, line 1)\\n\\nThe error appears to be in '/opt/ansible/roles/eda/tasks/deploy_eda.yml'
```

Instead, we can use the length filter for testing the string variable.