### PR TITLE
[AAP-12043] Add proper service account to eda-api server deployment. This is need…

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -33,7 +33,7 @@ spec:
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-api'
     spec:
-        serviceAccountName: '{{ ansible_operator_meta.name }}'
+      serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secrets | length > 0 %}
       imagePullSecrets:
 {% for secret in image_pull_secrets %}


### PR DESCRIPTION
[AAP-12043](https://issues.redhat.com/browse/AAP-12043)

Add proper service account to eda-api server deployment. 
This is needed for the enable/disable functionality on activations to work properly.