### PR TITLE
eda: Add resources limit to django-migration job

### DIFF
--- a/roles/eda/templates/migration-job.yaml.j2
+++ b/roles/eda/templates/migration-job.yaml.j2
@@ -57,6 +57,9 @@ spec:
                 mountPath: /app/src/src/aap_eda/settings/default.py
                 subPath: default.py
                 readOnly: true
+{% if combined_api.resource_requirements is defined %}
+          resources: {{ combined_api.resource_requirements }}
+{% endif %}
       restartPolicy: Never
       volumes:
         - name: {{ ansible_operator_meta.name }}-settings


### PR DESCRIPTION
This adds resources limit (cpu/mem) to the standalne django-migration job.
It currently reuse the limits defined for the API pod.