### PR TITLE
playbook: Replace awx reference by eda

### DIFF
--- a/playbooks/eda.yml
+++ b/playbooks/eda.yml
@@ -24,7 +24,7 @@
             name: redhat-operators-pull-secret
             namespace: '{{ ansible_operator_meta.namespace }}'
           stringData:
-            operator: awx
+            operator: eda
       when:
         - (_rh_ops_secret is not defined) or not (_rh_ops_secret['resources'] | length)
   roles:


### PR DESCRIPTION
This looks like a copy/paste from the awx-operator. Let's use eda instead.