### PR TITLE
config: Add status to EDA CRD/CSV

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -1474,6 +1474,42 @@ spec:
                 type: string
           status:
             description: Status defines the observed state of EDA
+            properties:
+              adminPasswordSecret:
+                description: Admin password secret name of the deployed instance
+                type: string
+              adminUser:
+                description: Admin user of the deployed instance
+                type: string
+              databaseConfigurationSecret:
+                description: Database Configuration secret name of the deployed instance
+                type: string
+              dbFieldsEncryptionSecret:
+                description: Database Fields Encryption secret name of the deployed instance
+                type: string
+              image:
+                description: URL of the image used for the deployed instance
+                type: string
+              version:
+                description: Version of the deployed instance
+                type: string
+              URL:
+                description: URL to access the deployed instance
+                type: string
+              conditions:
+                description: The resulting conditions when a Service Telemetry is instantiated
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -558,6 +558,42 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      statusDescriptors:
+      - description: Admin password for the instance deployed
+        displayName: Admin Password
+        path: adminPasswordSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Admin user for the instance deployed
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Database Configuration secret name of the deployed instance
+        displayName: Database Configuration
+        path: databaseConfigurationSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Database Fields Encryption secret name of the deployed instance
+        displayName: Database Fields Encryption
+        path: dbFieldsEncryptionSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Image of the instance deployed
+        displayName: Image
+        path: image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Version of the instance deployed
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Route to access the instance deployed
+        displayName: URL
+        path: URL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
       version: v1alpha1
   description: |
     An ansible operator for managing the lifecycle of an Event-Driven Ansible


### PR DESCRIPTION
The ansible code is updating correctly the status variables but they are configured in the status section for:
- EDA CRD (status)
- CSV file (statusDescriptors)

This is already in place for the backup and restore CRDs.