### PR TITLE
Add Contributing, Debugging, and Basic install docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+
+## Development Environment
+
+There are a couple ways to make and test changes to an Ansible operator. The easiest way is to build and deploy the operator from your branch using the make targets. This is closed to how the operator will be used, and is what is documented below. However, it may be useful to run the EDA Operator roles directly on your local machine for faster iteration. This involves a bit more set up, and is described in the [Debugging docs](./docs/debugging.md).
+
+First, you need to have a k8s cluster up. If you don't already have a k8s cluster, you can use minikube to start a lightweight k8s cluster locally by following these [minikube test cluster docs](./docs/minikube-test-cluster.md).
+
+
+
+### Build Operator Image
+
+Clone the eda-server-operator
+
+```
+git clone git@github.com:ansible/eda-server-operator.git
+```
+
+Create an image repo in your user called `eda-server-operator` on [quay.io](https://quay.io) or your preferred image registry. 
+
+Build & push the operator image
+
+```
+export QUAY_USER=username
+export TAG=feature-branch
+make docker-build docker-push IMG=quay.io/$QUAY_USER/eda-server-operator:$TAG
+```
+
+
+### Deploy EDA Operator
+
+
+1. Log in to your K8s or Openshift cluster.
+
+```
+kubectl login <cluster-url>
+```
+
+2. Run the `make deploy` target
+
+```
+NAMESPACE=eda IMG=quay.io/$QUAY_USER/eda-server-operator:$TAG make deploy
+```
+> **Note** The `latest` tag on the quay.io/ansible/eda-server-operator repo is the latest _released_ (tagged) version and the `main` tag is built from the HEAD of the `main` branch. To deploy with the latest code in `main` branch, check out the main branch, and use `IMG=quay.io/ansible/eda-server-operator:main` instead.
+
+
+### Create an EDA CR
+
+Create a yaml file defining the EDA custom resource
+
+```yaml
+# eda.yaml
+apiVersion: eda.ansible.com/v1alpha1
+kind: EDA
+metadata:
+  name: my-eda
+spec:
+  automation_server_url: https://awx-host
+```
+
+3. Now apply this yaml
+
+```bash
+$ kubectl apply -f eda.yaml
+```

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,139 @@
+# Debugging the EDA Operator
+
+## General Debugging
+
+When the operator is deploying EDA, it is running the `eda` role inside the operator container. If the EDA CR's status is `Failed`, it is often useful to look at the eda-server-operator container logs, which shows the output of the installer role. To see these logs, run:
+
+```
+kubectl logs deployments/eda-server-operator-controller-manager -c eda-server-manager -f
+```
+
+### Inspect k8s Resources
+
+Past that, it is often useful to inspect various resources the EDA Operator manages like:
+* eda
+* edabackup
+* edarestore
+* pod
+* deployment
+* statefulset
+* pvc
+* service
+* ingress
+* route
+* secrets
+* serviceaccount
+
+And if installing via OperatorHub and OLM:
+* subscription
+* csv
+* installPlan
+* catalogSource
+
+To inspect these resources you can use these commands
+
+```
+# Inspecting k8s resources
+kubectl describe -n <namespace> <resource> <resource-name>
+kubectl get -n <namespace> <resource> <resource-name> -o yaml
+kubectl logs -n <namespace> <resource> <resource-name>
+
+# Inspecting Pods
+kubectl exec -it -n <namespace> <pod> <pod-name>
+```
+
+
+### Configure No Log
+
+It is possible to show task output for debugging by setting no_log to false on the EDA CR spec.
+This will show output in the eda-server-operator logs for any failed tasks where no_log was set to true.
+
+For example:
+
+```yaml
+apiVersion: eda.ansible.com/v1alpha1
+kind: EDA
+metadata:
+  name: my-eda
+spec:
+  automation_server_url: https://awx-host
+  no_log: false                  # <------------
+```
+
+## Iterating on the installer without deploying the operator
+
+Go through the [normal basic install](https://github.com/ansible/eda-server-operator/blob/devel/README.md#install-the-eda-server-operator) steps.
+
+Install some dependencies:
+
+```
+$ ansible-galaxy collection install -r molecule/requirements.yml
+$ pip install -r molecule/requirements.txt
+```
+
+To prevent the changes we're about to make from being overwritten, scale down any running instance of the operator:
+
+```
+$ kubectl scale deployment eda-server-operator-controller-manager --replicas=0
+```
+
+Create a playbook that invokes the installer role (the operator uses ansible-runner's role execution feature):
+
+```yaml
+# run.yml
+---
+- hosts: localhost
+  vars:
+    automation_server_url: https://awx-host.com/
+    automation_server_ssl_verify: 'no'
+    service_type: ClusterIP
+    ingress_type: Route
+
+    no_log: false
+    ansible_operator_meta:
+      name: eda
+      namespace: eda
+    set_self_labels: false
+      #image: quay.io/username/eda-server
+      #image_version: feature-branch
+      #image_web: quay.io/username/eda-ui
+      #image_web_version: feature-branch
+    api:
+      replicas: 1
+      resource_requirements:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+    worker:
+      replicas: 1
+      resource_requirements:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+    ui:
+      replicas: 1
+      resource_requirements:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+    image_pull_policy: Always
+
+  tasks:
+    - include_role:
+        name: eda
+```
+
+
+Run the installer:
+
+```
+$ ansible-playbook run.yml -e @vars.yml -v
+```
+
+Grab the URL and admin password:
+
+```
+$ minikube service eda-ui --url -n eda
+$ minikube kubectl get secret eda-admin-password -- -o jsonpath="{.data.password}" | base64 --decode
+LU6lTfvnkjUvDwL240kXKy1sNhjakZmT
+```

--- a/docs/kustomize-install.md
+++ b/docs/kustomize-install.md
@@ -1,6 +1,6 @@
 # Install EDA Server Operator with Kustomize
 
-Some folks may prefer to install the EDA Server Operator using kustomize directly with a personalized kustomize file.  This allows you to easily modify configuration files including the operator's manager deployment itself. To do so, follow the instructions below.  
+Some folks may prefer to install the EDA Server Operator using [kustomize](https://kustomize.io/) directly with a personalized kustomize file. This allows you to easily modify configuration files including the operator's manager deployment itself. To do so, follow the instructions below.
 
 
 1. Create a `kustomization.yaml` file with the the following contents. Be sure to change `newTag` to the latest released tag, or the tag you would like to deploy.
@@ -25,10 +25,7 @@ namespace: eda
 ```
 kustomize build . | kubectl apply -f -
 ```
-
-For more information on how to use kustomize to modify configuration files dynamically, see these docs:
-* Kustomize documentation - https://kustomize.io/
-* Using Kustomize to deploy an ansible-operator - https://sdk.operatorframework.io/docs/building-operators/ansible/tutorial/
+> **TIP:** If you need to change any of the default settings for the operator (such as resources.limits), you can add [patches](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/) at the bottom of your kustomization.yaml file. There is also some useful information in [this ansible operator turotial](https://sdk.operatorframework.io/docs/building-operators/ansible/tutorial).
 
 
 ### Install Latest

--- a/docs/minikube-test-cluster.md
+++ b/docs/minikube-test-cluster.md
@@ -1,0 +1,50 @@
+# Creating a minikube cluster for testing
+
+If you do not have an existing cluster, the `eda-server-operator` can be deployed on a [Minikube](https://minikube.sigs.k8s.io/docs/) cluster for testing purposes. Due to different OS and hardware environments, please refer to the official Minikube documentation for further information.
+
+```
+$ minikube start --cpus=4 --memory=6g --addons=ingress
+😄  minikube v1.23.2 on Fedora 34
+✨  Using the docker driver based on existing profile
+👍  Starting control plane node minikube in cluster minikube
+🚜  Pulling base image ...
+🏃  Updating the running docker "minikube" container ...
+🐳  Preparing Kubernetes v1.22.2 on Docker 20.10.8 ...
+🔎  Verifying Kubernetes components...
+    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
+    ▪ Using image k8s.gcr.io/ingress-nginx/controller:v1.0.0-beta.3
+    ▪ Using image k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+    ▪ Using image k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+🔎  Verifying ingress addon...
+🌟  Enabled addons: storage-provisioner, default-storageclass, ingress
+🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
+```
+
+Once Minikube is deployed, check if the node(s) and `kube-apiserver` communication is working as expected.
+
+```
+$ minikube kubectl -- get nodes
+NAME       STATUS   ROLES                  AGE    VERSION
+minikube   Ready    control-plane,master   113s   v1.22.2
+
+$ minikube kubectl -- get pods -A
+NAMESPACE       NAME                                        READY   STATUS      RESTARTS   AGE
+ingress-nginx   ingress-nginx-admission-create--1-kk67h     0/1     Completed   0          2m1s
+ingress-nginx   ingress-nginx-admission-patch--1-7mp2r      0/1     Completed   1          2m1s
+ingress-nginx   ingress-nginx-controller-69bdbc4d57-bmwg8   1/1     Running     0          2m
+kube-system     coredns-78fcd69978-q7nmx                    1/1     Running     0          2m
+kube-system     etcd-minikube                               1/1     Running     0          2m12s
+kube-system     kube-apiserver-minikube                     1/1     Running     0          2m16s
+kube-system     kube-controller-manager-minikube            1/1     Running     0          2m12s
+kube-system     kube-proxy-5mmnw                            1/1     Running     0          2m1s
+kube-system     kube-scheduler-minikube                     1/1     Running     0          2m15s
+kube-system     storage-provisioner                         1/1     Running     0          2m11s
+```
+
+It is not required for `kubectl` to be separately installed since it comes already wrapped inside minikube. As demonstrated above, simply prefix `minikube kubectl --` before kubectl command, i.e. `kubectl get nodes` would become `minikube kubectl -- get nodes`
+
+Let's create an alias for easier usage:
+
+```
+$ alias kubectl="minikube kubectl --"
+```


### PR DESCRIPTION
Add the following guides, and refactor the README.md
* Contributing guide
* Debugging guide
* Basic install - default to kustomize now for consistency and document `make deploy` style install in the Contributing.md
* Reference the soon to be public eda-server repo