### PR TITLE
eda: Use gunicorn for running the API

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -90,6 +90,14 @@ spec:
                   replicas: 1
                 description: Defines desired state of eda-api resources
                 properties:
+                  gunicorn_workers:
+                    default: 2
+                    description: 'The number of gunicorn workers for the api.
+                      Default: 2'
+                    format: int32
+                    minimum: 1
+                    nullable: false
+                    type: integer
                   node_selector:
                     additionalProperties:
                       type: string

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -323,6 +323,12 @@ spec:
         path: api
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: The number of gunicorn workers for the API.
+        displayName: Gunicorn API workers
+        path: api.gunicorn_workers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:number
       - displayName: API server resource requirements
         path: api.resource_requirements
         x-descriptors:

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -28,6 +28,7 @@ websocket_ssl_verify: false
 
 api: {}
 _api:
+  gunicorn_workers: 2
   replicas: 1
   resource_requirements:
     requests:

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -150,7 +150,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - aap-eda-manage runserver 0.0.0.0:8000
+        - gunicorn --bind 0.0.0.0:8000 --workers {{ combined_api.gunicorn_workers }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'


### PR DESCRIPTION
The django runserver command isn't designed to be ran in production but only for development workflow.
Instead we should use gunicorn since that's the workflow used for VM based installer.