### PR TITLE
Revert "api: Use loopback for gunicorn/daphne bind config"

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -205,16 +205,16 @@ spec:
           httpGet:
             path: /_healthz
             port: 8000
-          failureThreshold: 1
+          failureThreshold: 10
           periodSeconds: 10
-          initialDelaySeconds: 30
+          initialDelaySeconds: 90
         livenessProbe:
           httpGet:
             path: /_healthz
             port: 8000
-          failureThreshold: 1
+          failureThreshold: 10
           periodSeconds: 10
-          initialDelaySeconds: 30
+          initialDelaySeconds: 90
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -150,7 +150,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - gunicorn --bind 127.0.0.1:8000 --workers {{ combined_api.gunicorn_workers }} aap_eda.wsgi:application
+        - gunicorn --bind 0.0.0.0:8000 --workers {{ combined_api.gunicorn_workers }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
@@ -224,7 +224,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - daphne -b 127.0.0.1 -p 8001 aap_eda.asgi:application
+        - daphne -b 0.0.0.0 -p 8001 aap_eda.asgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'


### PR DESCRIPTION
This reverts commit 0264d6872286ac8a1249c82ff3f2c3bf59e78f2e.

After we changed the gunicorn port from 0.0.0.0 to 127.0.0.1, the api container no longer comes up. The logs in the API container look OK, but the readiness and liveliness probes are not successful.

This is a perfect example of why our next focus should be putting in a basic deployment CI check :)