### PR TITLE
Change postgres_data_path default value

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -1305,7 +1305,7 @@ spec:
                     type: object
                   postgres_data_path:
                     description: 'Registry path to the PostgreSQL container to use.
-                      Default: "/var/lib/postgresql/data/pgdata"'
+                      Default: "/var/lib/pgsql/data/userdata"'
                     type: string
                   postgres_extra_args:
                     description: Arguments to pass to postgres process

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -39,7 +39,7 @@ _database:
   node_selector: ''
   priority_class: ''
   tolerations: ''
-  postgres_data_path: '/var/lib/postgresql/data/pgdata'
+  postgres_data_path: '/var/lib/pgsql/data/userdata'
   postgres_extra_args: ''
   database_secret: '' # Name of k8s secret containing postgres host, username, password, database, port, and type
 


### PR DESCRIPTION
When the PostgreSQL pod is deployed, the mountPath defined  is `/var/lib/postgresql`. However, the path that is mounted to the PersistentVolumeClaim is `/var/lib/pgsql`