### PR TITLE
backup/restore: use sclorg postgresql image

### DIFF
--- a/roles/backup/vars/main.yml
+++ b/roles/backup/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 deployment_type: "eda"
-_postgres_image: postgres
-_postgres_image_version: 13
+_postgres_image: quay.io/sclorg/postgresql-13-c8s
+_postgres_image_version: latest
 backup_complete: false
 database_type: "unmanaged"
 supported_pg_version: 13

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -2,8 +2,8 @@
 
 deployment_type: "eda"
 supported_pg_version: 13
-_postgres_image: postgres
-_postgres_image_version: 13
+_postgres_image: quay.io/sclorg/postgresql-13-c8s
+_postgres_image_version: latest
 
 backup_api_version: '{{ deployment_type }}.ansible.com/v1alpha1'
 backup_kind: 'EDABackup'


### PR DESCRIPTION
In 1ebe3a09 we switched the postgresql and redis images to use the ones from sclorg on quay.io registry.
However, the backup and restore roles were not updated with that change.