### PR TITLE
Make it possible to configure custom hostname for the ingress

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -1473,6 +1473,9 @@ spec:
               db_fields_encryption_secret:
                 description: Secret where the DB fields encryption key can be found. If not specified, one will be generated.
                 type: string
+              hostname:
+                description: The hostname of the instance
+                type: string
               admin_user:
                 description: Username to use for the admin account
                 type: string

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -186,6 +186,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Hostname
+        path: hostname
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Admin Account Username
         path: admin_user
         x-descriptors:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -101,7 +101,7 @@ rules:
     resources:
       - pods/exec
       - pods/attach
-      - pods/log  # log & attach rules needed to be able to grant them to AWX service account
+      - pods/log  # log & attach rules needed to be able to grant them to EDA service account
     verbs:
       - create
       - get


### PR DESCRIPTION
The ingress.yaml.j2 already supports this, but we neglected to add this parameter to the CRD schema when building the initial version of this operator.  