### PR TITLE
Set a default container for web & task deployments

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -32,6 +32,8 @@ spec:
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-api'
+      annotations:
+        kubectl.kubernetes.io/default-container: 'eda-api'
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secrets | length > 0 %}

--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -32,6 +32,8 @@ spec:
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-ui'
+      annotations:
+        kubectl.kubernetes.io/default-container: 'eda-ui'
     spec:
 {% if image_pull_secrets | length > 0 %}
       imagePullSecrets:

--- a/roles/eda/templates/eda-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-worker.deployment.yaml.j2
@@ -32,6 +32,8 @@ spec:
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
         app.kubernetes.io/component: '{{ deployment_type }}-worker'
+      annotations:
+        kubectl.kubernetes.io/default-container: 'eda-worker'
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secrets | length > 0 %}


### PR DESCRIPTION
 - This will make it so that when you query the pod for logs, it assumes the default container.

##### SUMMARY
Now when you query a pod for logs, it will assume the default container, saving you from having to pass `-c eda-api`, or something similar.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

