### PR TITLE
Fix CRD inconsistencies and remove unused redis storage class param

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -1149,9 +1149,6 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  redis_storage_class:
-                    description: Storage class to use for the Redis PVC
-                    type: string
                   strategy:
                     description: The deployment strategy to use to replace existing
                       pods with new ones.

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -448,14 +448,14 @@ spec:
         path: redis.node_selector
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: The deployment strategy to use to replace existing pods with
+      - description: Deployment strategy to use to replace existing pods with
           new ones.
         displayName: Strategy
         path: redis.strategy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: redis server resource requirements
+      - displayName: Redis deployment resource requirements
         path: redis.resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced


### PR DESCRIPTION
The `redis_storage_class` param was unused as we use an emptyDir to back the Redis data dir.  So this param was removed. 