### PR TITLE
fix: correct if statement for postgres_storage_class

### DIFF
--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -100,7 +100,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-{% if postgres_storage_class is defined %}
+{% if combined_database.postgres_storage_class is defined %}
         storageClassName: '{{ combined_database.postgres_storage_class }}'
 {% endif %}
         resources: {{ combined_database.storage_requirements }}


### PR DESCRIPTION
Closes #113 

I've built and deployed custom Operator image including this PR and tested with hostPath-based PV:

```yaml
---
apiVersion: v1
kind: PersistentVolume
metadata:
  name: eda-postgres-13-volume
spec:
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Retain
  capacity:
    storage: 8Gi
  storageClassName: eda-postgres-volume
  hostPath:
    path: /data/eda/postgres-13
```

```bash
sudo mkdir -p /data/eda/postgres-13/data
sudo chmod 755 /data/eda/postgres-13/data
sudo chown 26:0 /data/eda/postgres-13/data
```

```yaml
---
apiVersion: eda.ansible.com/v1alpha1
kind: EDA
metadata:
  name: eda
spec:
  ...
  database:
    ...
    postgres_storage_class: eda-postgres-volume
  ...
```

It works as expected:

```bash
$ kubectl -n eda get pv,pvc
NAME                                      CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS          REASON   AGE
...
persistentvolume/eda-postgres-13-volume   8Gi        RWO            Retain           Bound    eda/postgres-13-eda-postgres-13-0   eda-postgres-volume            7m17s

NAME                                                  STATUS   VOLUME                   CAPACITY   ACCESS MODES   STORAGECLASS          AGE
persistentvolumeclaim/postgres-13-eda-postgres-13-0   Bound    eda-postgres-13-volume   8Gi        RWO            eda-postgres-volume   6m53s

$ sudo ls -l /data/eda/postgres-13/data/userdata/
total 64
drwx------. 6 26 26    54 Aug  3 13:40 base
-rw-------. 1 26 26    30 Aug  3 13:40 current_logfiles
drwx------. 2 26 26  4096 Aug  3 13:41 global
drwx------. 2 26 26    32 Aug  3 13:40 log
drwx------. 2 26 26     6 Aug  3 13:40 pg_commit_ts
drwx------. 2 26 26     6 Aug  3 13:40 pg_dynshmem
-rw-------. 1 26 26  4958 Aug  3 13:40 pg_hba.conf
-rw-------. 1 26 26  1636 Aug  3 13:40 pg_ident.conf
drwx------. 4 26 26    68 Aug  3 13:40 pg_logical
drwx------. 4 26 26    36 Aug  3 13:40 pg_multixact
drwx------. 2 26 26     6 Aug  3 13:40 pg_notify
drwx------. 2 26 26     6 Aug  3 13:40 pg_replslot
drwx------. 2 26 26     6 Aug  3 13:40 pg_serial
drwx------. 2 26 26     6 Aug  3 13:40 pg_snapshots
drwx------. 2 26 26     6 Aug  3 13:40 pg_stat
drwx------. 2 26 26    63 Aug  3 13:41 pg_stat_tmp
drwx------. 2 26 26    18 Aug  3 13:40 pg_subtrans
drwx------. 2 26 26     6 Aug  3 13:40 pg_tblspc
drwx------. 2 26 26     6 Aug  3 13:40 pg_twophase
-rw-------. 1 26 26     3 Aug  3 13:40 PG_VERSION
drwx------. 3 26 26    60 Aug  3 13:40 pg_wal
drwx------. 2 26 26    18 Aug  3 13:40 pg_xact
-rw-------. 1 26 26    88 Aug  3 13:40 postgresql.auto.conf
-rw-------. 1 26 26 28163 Aug  3 13:40 postgresql.conf
-rw-------. 1 26 26    18 Aug  3 13:40 postmaster.opts
-rw-------. 1 26 26    98 Aug  3 13:40 postmaster.pid
```
