### PR TITLE
fix: correct configmap to make extra_settings work

### DIFF
--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -64,7 +64,7 @@ spec:
         - aap-eda-manage rqworker --with-scheduler --worker-class aap_eda.core.tasking.ActivationWorker
         envFrom:
           - configMapRef:
-              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         env:
         - name: EDA_DB_HOST
           valueFrom:
@@ -91,21 +91,11 @@ spec:
             secretKeyRef:
               name: '{{ __database_secret }}'
               key: password
-        - name: EDA_MQ_HOST
-          value: {{ ansible_operator_meta.name }}-redis-svc
         - name: EDA_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
-        - name: EDA_CONTROLLER_URL
-          value: "{{ automation_server_url }}"
-        - name: EDA_CONTROLLER_SSL_VERIFY
-          value: "{{ automation_server_ssl_verify | default('yes')}}"
-        - name: EDA_WEBSOCKET_BASE_URL
-          value: 'ws://{{ websocket_server_name }}:8001'
-        - name: EDA_WEBSOCKET_SSL_VERIFY
-          value: '{{ websocket_ssl_verify }}'
         ports:
         - containerPort: 8000
 {% if combined_activation_worker.resource_requirements is defined %}

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -61,12 +61,8 @@ spec:
         command: ['aap-eda-manage', 'migrate']
         envFrom:
           - configMapRef:
-              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         env:
-        - name: EDA_DEPLOYMENT_TYPE
-          value: 'k8s'
-        - name: EDA_ALLOWED_HOSTS
-          value: "['*']"
         - name: EDA_DB_HOST
           valueFrom:
             secretKeyRef:
@@ -106,12 +102,8 @@ spec:
         command: ['aap-eda-manage', 'create_initial_data']
         envFrom:
           - configMapRef:
-              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         env:
-        - name: EDA_DEPLOYMENT_TYPE
-          value: 'k8s'
-        - name: EDA_ALLOWED_HOSTS
-          value: "['*']"
         - name: EDA_DB_HOST
           valueFrom:
             secretKeyRef:
@@ -155,10 +147,8 @@ spec:
         - gunicorn --bind 0.0.0.0:8000 --workers {{ combined_api.gunicorn_workers }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
-              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         env:
-        - name: EDA_DEPLOYMENT_TYPE
-          value: 'k8s'
         - name: EDA_DB_HOST
           valueFrom:
             secretKeyRef:
@@ -184,23 +174,11 @@ spec:
             secretKeyRef:
               name: '{{ __database_secret }}'
               key: password
-        - name: EDA_ALLOWED_HOSTS
-          value: "['*']"
-        - name: EDA_MQ_HOST
-          value: {{ ansible_operator_meta.name }}-redis-svc
         - name: EDA_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
-        - name: EDA_CONTROLLER_URL
-          value: "{{ automation_server_url }}"
-        - name: EDA_CONTROLLER_SSL_VERIFY
-          value: "{{ automation_server_ssl_verify | default('yes')}}"
-        - name: EDA_WEBSOCKET_BASE_URL
-          value: 'ws://{{ websocket_server_name }}:8001'
-        - name: EDA_WEBSOCKET_SSL_VERIFY
-          value: '{{ websocket_ssl_verify }}'
         ports:
         - containerPort: 8000
         readinessProbe:
@@ -229,10 +207,8 @@ spec:
         - daphne -b 0.0.0.0 -p 8001 aap_eda.asgi:application
         envFrom:
           - configMapRef:
-              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         env:
-        - name: EDA_DEPLOYMENT_TYPE
-          value: 'k8s'
         - name: EDA_DB_HOST
           valueFrom:
             secretKeyRef:
@@ -258,23 +234,11 @@ spec:
             secretKeyRef:
               name: '{{ __database_secret }}'
               key: password
-        - name: EDA_ALLOWED_HOSTS
-          value: "['*']"
-        - name: EDA_MQ_HOST
-          value: {{ ansible_operator_meta.name }}-redis-svc
         - name: EDA_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
-        - name: EDA_CONTROLLER_URL
-          value: "{{ automation_server_url }}"
-        - name: EDA_CONTROLLER_SSL_VERIFY
-          value: "{{ automation_server_ssl_verify | default('yes')}}"
-        - name: EDA_WEBSOCKET_BASE_URL
-          value: 'ws://{{ websocket_server_name }}:8001'
-        - name: EDA_WEBSOCKET_SSL_VERIFY
-          value: '{{ websocket_ssl_verify }}'
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -64,7 +64,7 @@ spec:
         - aap-eda-manage rqworker --with-scheduler --worker-class aap_eda.core.tasking.DefaultWorker
         envFrom:
           - configMapRef:
-              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         env:
         - name: EDA_DB_HOST
           valueFrom:
@@ -91,21 +91,11 @@ spec:
             secretKeyRef:
               name: '{{ __database_secret }}'
               key: password
-        - name: EDA_MQ_HOST
-          value: {{ ansible_operator_meta.name }}-redis-svc
         - name: EDA_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
-        - name: EDA_CONTROLLER_URL
-          value: "{{ automation_server_url }}"
-        - name: EDA_CONTROLLER_SSL_VERIFY
-          value: "{{ automation_server_ssl_verify | default('yes')}}"
-        - name: EDA_WEBSOCKET_BASE_URL
-          value: 'ws://{{ websocket_server_name }}:8001'
-        - name: EDA_WEBSOCKET_SSL_VERIFY
-          value: '{{ websocket_ssl_verify }}'
         ports:
         - containerPort: 8000
 {% if combined_default_worker.resource_requirements is defined %}

--- a/roles/eda/templates/eda-scheduler.deployment.yaml.j2
+++ b/roles/eda/templates/eda-scheduler.deployment.yaml.j2
@@ -61,7 +61,7 @@ spec:
             - aap-eda-manage scheduler
         envFrom:
         - configMapRef:
-            name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+            name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         env:
         - name: EDA_DB_HOST
           valueFrom:
@@ -88,21 +88,11 @@ spec:
             secretKeyRef:
               name: '{{ __database_secret }}'
               key: password
-        - name: EDA_MQ_HOST
-          value: {{ ansible_operator_meta.name }}-redis-svc
         - name: EDA_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
-        - name: EDA_CONTROLLER_URL
-          value: "{{ automation_server_url }}"
-        - name: EDA_CONTROLLER_SSL_VERIFY
-          value: "{{ automation_server_ssl_verify | default('yes')}}"
-        - name: EDA_WEBSOCKET_BASE_URL
-          value: 'ws://{{ websocket_server_name }}:8001'
-        - name: EDA_WEBSOCKET_SSL_VERIFY
-          value: '{{ websocket_ssl_verify }}'
 {% if combined_worker.resource_requirements is defined %}
         resources: {{ combined_worker.resource_requirements }}
 {% endif %}

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -3,28 +3,37 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+data:
+  # Operator specific settings
+  EDA_DEPLOYMENT_TYPE: "k8s"
+
+  # AWX Server
+  EDA_CONTROLLER_URL: "{{ automation_server_url }}"
+  EDA_CONTROLLER_SSL_VERIFY: "{{ automation_server_ssl_verify | default('yes')}}"
+
+  # EDA Server
+  EDA_ALLOWED_HOSTS: "['*']"
+  EDA_MQ_HOST: "{{ ansible_operator_meta.name }}-redis-svc"
+  EDA_WEBSOCKET_BASE_URL: "ws://{{ websocket_server_name }}:8001"
+  EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"
+
+  # Custom user variables
+{% for item in extra_settings | default([]) %}
+  {{ item.setting | upper }}: "{{ item.value }}"
+{% endfor %}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
   namespace: '{{ ansible_operator_meta.namespace }}'
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 data:
-  settings: |
-
-    # Operator specific settings
-    DEPLOYMENT_TYPE=k8s
-
-    # AWX Server
-    EDA_CONTROLLER_SSL_VERIFY=no
-
-    # EDA Server
-    EDA_WEBSOCKET_BASE_URL=ws://eda-api:8000
-    EDA_WEBSOCKET_SSL_VERIFY=no
-
-    # Custom user variables
-{% for item in extra_settings | default([]) %}
-    {{ item.setting | upper }}={{ item.value }}
-{% endfor %}
-
   nginx_conf: |
     events {
         worker_connections 1024;


### PR DESCRIPTION
Closes #112

This PR includes following changes:

- Add new configmap: `*-env-propertie` that includes environment variables for EDA Controller
  - The name of the configmap came from [manifests on eda-server repo](https://github.com/ansible/eda-server/blob/6346a5e5571d69f70f36fdf16a8e5e3b8299f6d0/tools/deploy/kustomization.yaml#L23)
- Move following environment variables from under `env` per deployment to new configmap:
  - `EDA_DEPLOYMENT_TYPE`
  - `EDA_ALLOWED_HOSTS`
  - `EDA_MQ_HOST`
  - `EDA_CONTROLLER_URL`
  - `EDA_CONTROLLER_SSL_VERIFY`
  - `EDA_WEBSOCKET_BASE_URL`
  - `EDA_WEBSOCKET_SSL_VERIFY`

Tested with following CR:

```yaml
---
apiVersion: eda.ansible.com/v1alpha1
kind: EDA
metadata:
  name: eda
spec:
  ...
  extra_settings:
    - setting: GIT_SSL_NO_VERIFY
      value: "true"
```

Result:

```bash
$ kubectl -n eda exec -it eda-worker-69b97bc457-pbjbf -- bash
[eda@eda-worker-69b97bc457-pbjbf src]$ echo "$EDA_DEPLOYMENT_TYPE"
k8s
[eda@eda-worker-69b97bc457-pbjbf src]$ echo "$EDA_ALLOWED_HOSTS"
['*']
[eda@eda-worker-69b97bc457-pbjbf src]$ echo "$EDA_MQ_HOST"
eda-redis-svc
[eda@eda-worker-69b97bc457-pbjbf src]$ echo "$EDA_CONTROLLER_URL"
https://awx.example.com/
[eda@eda-worker-69b97bc457-pbjbf src]$ echo "$EDA_CONTROLLER_SSL_VERIFY"
no
[eda@eda-worker-69b97bc457-pbjbf src]$ echo "$EDA_WEBSOCKET_BASE_URL"
ws://eda-daphne:8001
[eda@eda-worker-69b97bc457-pbjbf src]$ echo "$EDA_WEBSOCKET_SSL_VERIFY"
False
[eda@eda-worker-69b97bc457-pbjbf src]$ echo "$GIT_SSL_NO_VERIFY"
true
```