### PR TITLE
fix: correct worker into default worker and activation worker

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -757,10 +757,10 @@ spec:
                       type: object
                     type: array
                 type: object
-              worker:
+              default_worker:
                 default:
                   replicas: 5
-                description: Defines desired state of eda-worker resources
+                description: Defines desired state of eda-default-worker resources
                 properties:
                   node_selector:
                     additionalProperties:
@@ -769,14 +769,346 @@ spec:
                     type: object
                   replicas:
                     default: 2
-                    description: 'Size is the size of number of eda-worker replicas.
+                    description: 'Size is the size of number of eda-default-worker replicas.
                       Default: 1'
                     format: int32
                     minimum: 0
                     nullable: true
                     type: integer
                   resource_requirements:
-                    description: Resource requirements for the eda-worker container.
+                    description: Resource requirements for the eda-default-worker container.
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  strategy:
+                    description: The deployment strategy to use to replace existing
+                      pods with new ones.
+                    properties:
+                      rollingUpdate:
+                        description: 'Rolling update config params. Present only if
+                          DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                          this to follow our convention for oneOf, whatever we decide
+                          it to be.'
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'The maximum number of pods that can be scheduled
+                              above the desired number of pods. Value can be an absolute
+                              number (ex: 5) or a percentage of desired pods (ex:
+                              10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                              number is calculated from percentage by rounding up.
+                              Defaults to 25%. Example: when this is set to 30%, the
+                              new ReplicaSet can be scaled up immediately when the
+                              rolling update starts, such that the total number of
+                              old and new pods do not exceed 130% of desired pods.
+                              Once old pods have been killed, new ReplicaSet can be
+                              scaled up further, ensuring that total number of pods
+                              running at any time during the update is at most 130%
+                              of desired pods.'
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'The maximum number of pods that can be unavailable
+                              during the update. Value can be an absolute number (ex:
+                              5) or a percentage of desired pods (ex: 10%). Absolute
+                              number is calculated from percentage by rounding down.
+                              This can not be 0 if MaxSurge is 0. Defaults to 25%.
+                              Example: when this is set to 30%, the old ReplicaSet
+                              can be scaled down to 70% of desired pods immediately
+                              when the rolling update starts. Once new pods are ready,
+                              old ReplicaSet can be scaled down further, followed
+                              by scaling up the new ReplicaSet, ensuring that the
+                              total number of pods available at all times during the
+                              update is at least 70% of desired pods.'
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
+                  tolerations:
+                    description: Node tolerations for the EDA pods.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topology_spread_constraints:
+                    description: Topology rule(s) for the pods.
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is a beta field and requires
+                            the MinDomainsInPodTopologySpread feature gate to be enabled
+                            (enabled by default)."
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat
+                            Pod's nodeAffinity/nodeSelector when calculating pod topology
+                            spread skew. Options are: - Honor: only nodes matching
+                            nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
+                            are included in the calculations. \n If this value is
+                            nil, the behavior is equivalent to the Honor policy. This
+                            is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat
+                            node taints when calculating pod topology spread skew.
+                            Options are: - Honor: nodes without taints, along with
+                            tainted nodes for which the incoming pod has a toleration,
+                            are included. - Ignore: node taints are ignored. All nodes
+                            are included. \n If this value is nil, the behavior is
+                            equivalent to the Ignore policy. This is a beta-level
+                            feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: 'WhenUnsatisfiable indicates how to deal with
+                            a pod if it doesn''t satisfy the spread constraint. -
+                            DoNotSchedule (default) tells the scheduler not to schedule
+                            it. - ScheduleAnyway tells the scheduler to schedule the
+                            pod in any location, but giving higher precedence to topologies
+                            that would help reduce the skew. A constraint is considered
+                            "Unsatisfiable" for an incoming pod if and only if every
+                            possible node assignment for that pod would violate "MaxSkew"
+                            on some topology. For example, in a 3-zone cluster, MaxSkew
+                            is set to 1, and pods with the same labelSelector spread
+                            as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                            If WhenUnsatisfiable is set to DoNotSchedule, incoming
+                            pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                            as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1).
+                            In other words, the cluster can still be imbalanced, but
+                            scheduler won''t make it *more* imbalanced. It''s a required
+                            field.'
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                type: object
+              activation_worker:
+                default:
+                  replicas: 5
+                description: Defines desired state of eda-activation-worker resources
+                properties:
+                  node_selector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector for the EDA pods.
+                    type: object
+                  replicas:
+                    default: 2
+                    description: 'Size is the size of number of eda-activation-worker replicas.
+                      Default: 1'
+                    format: int32
+                    minimum: 0
+                    nullable: true
+                    type: integer
+                  resource_requirements:
+                    description: Resource requirements for the eda-activation-worker container.
                     properties:
                       claims:
                         description: "Claims lists the names of resources, defined

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -399,39 +399,74 @@ spec:
         path: ui.topology_spread_constraints
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Defines desired state of eda-worker deployment resources
-        displayName: Worker deployment configuration
-        path: worker
+      - description: Defines desired state of eda-default-worker deployment resources
+        displayName: Default worker deployment configuration
+        path: default_worker
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Worker pod resource requirements
-        path: worker.resource_requirements
+      - displayName: Default worker pod resource requirements
+        path: default_worker.resource_requirements
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - description: The number of Worker replicas.
+      - description: The number of default worker replicas.
         displayName: Replicas
-        path: worker.replicas
+        path: default_worker.replicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount
       - displayName: Node Selector
-        path: worker.node_selector
+        path: default_worker.node_selector
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: The deployment strategy to use to replace existing pods with
           new ones.
         displayName: Strategy
-        path: worker.strategy
+        path: default_worker.strategy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Node tolerations for the worker pods.
+      - description: Node tolerations for the default worker pods.
         displayName: Tolerations
-        path: worker.tolerations
+        path: default_worker.tolerations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Topology rule(s) for the pods.
         displayName: Topology Spread Constraints
-        path: worker.topology_spread_constraints
+        path: default_worker.topology_spread_constraints
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Defines desired state of eda-activation-worker deployment resources
+        displayName: Activation worker deployment configuration
+        path: activation_worker
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Activation worker pod resource requirements
+        path: activation_worker.resource_requirements
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The number of activation worker replicas.
+        displayName: Replicas
+        path: activation_worker.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - displayName: Node Selector
+        path: activation_worker.node_selector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: The deployment strategy to use to replace existing pods with
+          new ones.
+        displayName: Strategy
+        path: activation_worker.strategy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Node tolerations for the activation worker pods.
+        displayName: Tolerations
+        path: activation_worker.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Topology rule(s) for the pods.
+        displayName: Topology Spread Constraints
+        path: activation_worker.topology_spread_constraints
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Defines desired state of redis deployment resources

--- a/config/samples/eda_v1alpha1_eda.yaml
+++ b/config/samples/eda_v1alpha1_eda.yaml
@@ -19,7 +19,13 @@ spec:
       requests:
         cpu: 150m
         memory: 256Mi
-  worker:
+  default_worker:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+  activation_worker:
     replicas: 1
     resource_requirements:
       requests:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -104,7 +104,13 @@ Create a playbook that invokes the installer role (the operator uses ansible-run
         requests:
           cpu: 200m
           memory: 512Mi
-    worker:
+    default_worker:
+      replicas: 1
+      resource_requirements:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+    activation_worker:
       replicas: 1
       resource_requirements:
         requests:

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -37,8 +37,18 @@ _api:
   node_selector: ''
   tolerations: ''
 
-worker: {}
-_worker:
+default_worker: {}
+_default_worker:
+  replicas: 5
+  resource_requirements:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+  node_selector: ''
+  tolerations: ''
+
+activation_worker: {}
+_activation_worker:
   replicas: 5
   resource_requirements:
     requests:

--- a/roles/eda/tasks/combine_defaults.yml
+++ b/roles/eda/tasks/combine_defaults.yml
@@ -4,4 +4,5 @@
   set_fact:
     combined_api: "{{ _api | combine (api, recursive=True ) }}"
     combined_ui: "{{ _ui | combine (ui, recursive=True) }}"
-    combined_worker: "{{ _worker | combine (worker, recursive=True) }}"
+    combined_default_worker: "{{ _default_worker | combine (default_worker, recursive=True) }}"
+    combined_activation_worker: "{{ _activation_worker | combine (activation_worker, recursive=True) }}"

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -16,8 +16,10 @@
     - 'eda-ui.service'
     - 'eda-ui.deployment'
     - 'eda-ui.ingress'
-    - 'eda-worker.service'
-    - 'eda-worker.deployment'
+    - 'eda-default-worker.service'
+    - 'eda-default-worker.deployment'
+    - 'eda-activation-worker.service'
+    - 'eda-activation-worker.deployment'
 
 - name: Check for API Pod
   k8s_info:

--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -1,0 +1,120 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ ansible_operator_meta.name }}-activation-worker"
+  namespace: "{{ ansible_operator_meta.namespace }}"
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
+    {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
+    app.kubernetes.io/component: '{{ deployment_type }}-activation-worker'
+spec:
+  replicas: {{ combined_activation_worker.replicas }}
+{% if combined_activation_worker.strategy is defined %}
+  strategy:
+    type: {{ combined_activation_worker.strategy.type }}
+{% if combined_activation_worker.strategy.type == "Recreate" %}
+    rollingUpdate: null
+{% elif combined_activation_worker.strategy.type == "RollingUpdate" %}
+    rollingUpdate:
+      maxSurge:  {{ combined_activation_worker.strategy.rollingUpdate.maxSurge | default("25%")}}
+      maxUnavailable: {{ combined_activation_worker.strategy.rollingUpdate.maxUnavailable | default("25%")}}
+{% endif %}
+{% endif %}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
+      app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      app.kubernetes.io/component: '{{ deployment_type }}-activation-worker'
+  template:
+    metadata:
+      labels:
+        {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
+        {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
+        app.kubernetes.io/component: '{{ deployment_type }}-activation-worker'
+      annotations:
+        kubectl.kubernetes.io/default-container: 'eda-activation-worker'
+    spec:
+      serviceAccountName: '{{ ansible_operator_meta.name }}'
+{% if image_pull_secrets | length > 0 %}
+      imagePullSecrets:
+{% for secret in image_pull_secrets %}
+        - name: {{ secret }}
+{% endfor %}
+{% endif %}
+{% if combined_activation_worker.node_selector is defined %}
+      nodeSelector:
+        {{ combined_activation_worker.node_selector | indent(width=8) }}
+{% endif %}
+{% if combined_activation_worker.tolerations is defined %}
+      tolerations:
+        {{ combined_activation_worker.tolerations | indent(width=8) }}
+{% endif %}
+{% if combined_activation_worker.topology_spread_constraints is defined %} %}
+      topologySpreadConstraints:
+        {{ combined_activation_worker.topology_spread_constraints | indent(width=8) }}
+{% endif %}
+      containers:
+      - name: eda-activation-worker
+        image: {{ _image }}
+        imagePullPolicy: '{{ image_pull_policy }}'
+        args:
+        - /bin/bash
+        - -c
+        - aap-eda-manage rqworker --with-scheduler --worker-class aap_eda.core.tasking.ActivationWorker
+        envFrom:
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+        env:
+        - name: EDA_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __database_secret }}'
+              key: host
+        - name: EDA_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __database_secret }}'
+              key: database
+        - name: EDA_DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __database_secret }}'
+              key: port
+        - name: EDA_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __database_secret }}'
+              key: username
+        - name: EDA_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __database_secret }}'
+              key: password
+        - name: EDA_MQ_HOST
+          value: {{ ansible_operator_meta.name }}-redis-svc
+        - name: EDA_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: '{{ db_fields_encryption_secret_name }}'
+              key: secret_key
+        - name: EDA_CONTROLLER_URL
+          value: "{{ automation_server_url }}"
+        - name: EDA_CONTROLLER_SSL_VERIFY
+          value: "{{ automation_server_ssl_verify | default('yes')}}"
+        - name: EDA_WEBSOCKET_BASE_URL
+          value: 'ws://{{ websocket_server_name }}:8001'
+        - name: EDA_WEBSOCKET_SSL_VERIFY
+          value: '{{ websocket_ssl_verify }}'
+        ports:
+        - containerPort: 8000
+{% if combined_activation_worker.resource_requirements is defined %}
+        resources: {{ combined_activation_worker.resource_requirements }}
+{% endif %}
+        volumeMounts:
+          - name: "{{ ansible_operator_meta.name }}-media-data"
+            mountPath: "{{ media_dir }}"
+      restartPolicy: Always
+      volumes:
+        - name: {{ ansible_operator_meta.name }}-media-data
+          emptyDir: {}

--- a/roles/eda/templates/eda-activation-worker.service.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.service.yaml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ ansible_operator_meta.name }}-activation-worker"
+  namespace: "{{ ansible_operator_meta.namespace }}"
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
+    app.kubernetes.io/component: '{{ deployment_type }}-activation-worker'
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
+    app.kubernetes.io/component: '{{ deployment_type }}-activation-worker'

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -2,38 +2,38 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ ansible_operator_meta.name }}-worker"
+  name: "{{ ansible_operator_meta.name }}-default-worker"
   namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
     {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=4) | trim }}
-    app.kubernetes.io/component: '{{ deployment_type }}-worker'
+    app.kubernetes.io/component: '{{ deployment_type }}-default-worker'
 spec:
-  replicas: {{ combined_worker.replicas }}
-{% if combined_worker.strategy is defined %}
+  replicas: {{ combined_default_worker.replicas }}
+{% if combined_default_worker.strategy is defined %}
   strategy:
-    type: {{ combined_worker.strategy.type }}
-{% if combined_worker.strategy.type == "Recreate" %}
+    type: {{ combined_default_worker.strategy.type }}
+{% if combined_default_worker.strategy.type == "Recreate" %}
     rollingUpdate: null
-{% elif combined_worker.strategy.type == "RollingUpdate" %}
+{% elif combined_default_worker.strategy.type == "RollingUpdate" %}
     rollingUpdate:
-      maxSurge:  {{ combined_worker.strategy.rollingUpdate.maxSurge | default("25%")}}
-      maxUnavailable: {{ combined_worker.strategy.rollingUpdate.maxUnavailable | default("25%")}}
+      maxSurge:  {{ combined_default_worker.strategy.rollingUpdate.maxSurge | default("25%")}}
+      maxUnavailable: {{ combined_default_worker.strategy.rollingUpdate.maxUnavailable | default("25%")}}
 {% endif %}
 {% endif %}
   selector:
     matchLabels:
       app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
       app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
-      app.kubernetes.io/component: '{{ deployment_type }}-worker'
+      app.kubernetes.io/component: '{{ deployment_type }}-default-worker'
   template:
     metadata:
       labels:
         {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=8) | trim }}
         {{ lookup("template", "../common/templates/labels/version.yaml.j2") | indent(width=8) | trim }}
-        app.kubernetes.io/component: '{{ deployment_type }}-worker'
+        app.kubernetes.io/component: '{{ deployment_type }}-default-worker'
       annotations:
-        kubectl.kubernetes.io/default-container: 'eda-worker'
+        kubectl.kubernetes.io/default-container: 'eda-default-worker'
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secrets | length > 0 %}
@@ -42,26 +42,26 @@ spec:
         - name: {{ secret }}
 {% endfor %}
 {% endif %}
-{% if combined_worker.node_selector is defined %}
+{% if combined_default_worker.node_selector is defined %}
       nodeSelector:
-        {{ combined_worker.node_selector | indent(width=8) }}
+        {{ combined_default_worker.node_selector | indent(width=8) }}
 {% endif %}
-{% if combined_worker.tolerations is defined %}
+{% if combined_default_worker.tolerations is defined %}
       tolerations:
-        {{ combined_worker.tolerations | indent(width=8) }}
+        {{ combined_default_worker.tolerations | indent(width=8) }}
 {% endif %}
-{% if combined_worker.topology_spread_constraints is defined %} %}
+{% if combined_default_worker.topology_spread_constraints is defined %} %}
       topologySpreadConstraints:
-        {{ combined_worker.topology_spread_constraints | indent(width=8) }}
+        {{ combined_default_worker.topology_spread_constraints | indent(width=8) }}
 {% endif %}
       containers:
-      - name: eda-worker
+      - name: eda-default-worker
         image: {{ _image }}
         imagePullPolicy: '{{ image_pull_policy }}'
         args:
         - /bin/bash
         - -c
-        - aap-eda-manage rqworker --with-scheduler --worker-class aap_eda.core.tasking.Worker
+        - aap-eda-manage rqworker --with-scheduler --worker-class aap_eda.core.tasking.DefaultWorker
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
@@ -108,8 +108,8 @@ spec:
           value: '{{ websocket_ssl_verify }}'
         ports:
         - containerPort: 8000
-{% if combined_worker.resource_requirements is defined %}
-        resources: {{ combined_worker.resource_requirements }}
+{% if combined_default_worker.resource_requirements is defined %}
+        resources: {{ combined_default_worker.resource_requirements }}
 {% endif %}
         volumeMounts:
           - name: "{{ ansible_operator_meta.name }}-media-data"

--- a/roles/eda/templates/eda-default-worker.service.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.service.yaml.j2
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ ansible_operator_meta.name }}-worker"
+  name: "{{ ansible_operator_meta.name }}-default-worker"
   namespace: "{{ ansible_operator_meta.namespace }}"
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
-    app.kubernetes.io/component: '{{ deployment_type }}-worker'
+    app.kubernetes.io/component: '{{ deployment_type }}-default-worker'
 spec:
   ports:
   - port: 8080
@@ -14,4 +14,4 @@ spec:
     targetPort: 8080
   selector:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2")  | indent(width=4) | trim }}
-    app.kubernetes.io/component: '{{ deployment_type }}-worker'
+    app.kubernetes.io/component: '{{ deployment_type }}-default-worker'


### PR DESCRIPTION
Closes #111 

Changes:

- Replace existing worker as default worker, and duplicate it as activation worker
- Modify args for `aap-eda-manage` in workers into `aap_eda.core.tasking.DefaultWorker` and `aap_eda.core.tasking.ActivationWorker`

I don't know what the service resource for worker is for since no service exists on [the manifests on eda-server repo](https://github.com/ansible/eda-server/tree/f7b2c73120dae4344288e74786d842d4049c6bc4/tools/deploy/eda-default-worker), but I create it for both workers to keep it as-is.

Note that this PR will cause conflicts with my other PRs, but since I don't know which PR will be approved, I'm keeping this in a way that it doesn't conflict with the `main` branch.
If conflicts arise in my PRs, including this, I will resolve them and push them, but please let me know if it is better to combine all (or specific) PRs into one PR.

Tested with:

```yaml
---
apiVersion: eda.ansible.com/v1alpha1
kind: EDA
metadata:
  name: eda
spec:
  ...
  api:
    replicas: 1
    resource_requirements:
      requests: {}
  ui:
    replicas: 1
    resource_requirements:
      requests: {}
  default_worker:
    replicas: 1
    resource_requirements:
      requests: {}
  activation_worker:
    replicas: 2
    resource_requirements:
      requests: {}
  redis:
    replicas: 1
    resource_requirements:
      requests: {}
```

Result:

```bash
$ kubectl -n eda logs deployments/eda-server-operator-controller-manager
...
----- Ansible Task Status Event StdOut (eda.ansible.com/v1alpha1, Kind=EDA, eda/eda) -----

PLAY RECAP *********************************************************************
localhost                  : ok=53   changed=0    unreachable=0    failed=0    skipped=17   rescued=0    ignored=0   
...

$ kubectl -n eda get pod,deployment,service
NAME                                                          READY   STATUS    RESTARTS   AGE
pod/eda-server-operator-controller-manager-6f974597f5-jgk6v   2/2     Running   0          5m9s
pod/eda-redis-7d78cdf7d5-npmvk                                1/1     Running   0          4m47s
pod/eda-postgres-13-0                                         1/1     Running   0          4m38s
pod/eda-ui-7cc5f59787-bpnsn                                   1/1     Running   0          3m49s
pod/eda-default-worker-59cd95f9d4-85wfc                       1/1     Running   0          3m44s
pod/eda-activation-worker-9c4d9cfd-qxxc4                      1/1     Running   0          3m42s
pod/eda-activation-worker-9c4d9cfd-zdtbs                      1/1     Running   0          3m42s
pod/eda-api-7fc5d8d4d7-g8g6s                                  2/2     Running   0          3m52s

NAME                                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/eda-server-operator-controller-manager   1/1     1            1           5m9s
deployment.apps/eda-redis                                1/1     1            1           4m47s
deployment.apps/eda-ui                                   1/1     1            1           3m49s
deployment.apps/eda-default-worker                       1/1     1            1           3m44s
deployment.apps/eda-activation-worker                    2/2     2            2           3m42s
deployment.apps/eda-api                                  1/1     1            1           3m52s

NAME                                                             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/eda-server-operator-controller-manager-metrics-service   ClusterIP   10.43.151.68    <none>        8443/TCP   5m9s
service/eda-redis-svc                                            ClusterIP   10.43.80.219    <none>        6379/TCP   4m49s
service/eda-postgres-13                                          ClusterIP   None            <none>        5432/TCP   4m40s
service/eda-api                                                  ClusterIP   10.43.58.234    <none>        8000/TCP   3m53s
service/eda-daphne                                               ClusterIP   10.43.143.178   <none>        8001/TCP   3m53s
service/eda-ui                                                   ClusterIP   10.43.77.32     <none>        80/TCP     3m50s
service/eda-default-worker                                       ClusterIP   10.43.55.149    <none>        8080/TCP   3m46s
service/eda-activation-worker                                    ClusterIP   10.43.211.133   <none>        8080/TCP   3m43s
```