### PR TITLE
Set default_worker replicas to 2 by default

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -86,8 +86,6 @@ spec:
                 description: Redis container image tag or version to use
                 type: string
               api:
-                default:
-                  replicas: 1
                 description: Defines desired state of eda-api resources
                 properties:
                   gunicorn_workers:
@@ -426,8 +424,6 @@ spec:
                     type: array
                 type: object
               ui:
-                default:
-                  replicas: 1
                 description: Defines desired state of eda-ui resources
                 properties:
                   node_selector:
@@ -758,8 +754,6 @@ spec:
                     type: array
                 type: object
               default_worker:
-                default:
-                  replicas: 5
                 description: Defines desired state of eda-default-worker resources
                 properties:
                   node_selector:
@@ -1090,8 +1084,6 @@ spec:
                     type: array
                 type: object
               activation_worker:
-                default:
-                  replicas: 5
                 description: Defines desired state of eda-activation-worker resources
                 properties:
                   node_selector:
@@ -1100,9 +1092,9 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 2
+                    default: 5
                     description: 'Size is the size of number of eda-activation-worker replicas.
-                      Default: 1'
+                      Default: 5'
                     format: int32
                     minimum: 0
                     nullable: true

--- a/config/samples/eda_v1alpha1_eda.yaml
+++ b/config/samples/eda_v1alpha1_eda.yaml
@@ -20,13 +20,13 @@ spec:
         cpu: 150m
         memory: 256Mi
   default_worker:
-    replicas: 1
+    replicas: 2
     resource_requirements:
       requests:
         cpu: 150m
         memory: 256Mi
   activation_worker:
-    replicas: 1
+    replicas: 3
     resource_requirements:
       requests:
         cpu: 150m

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -105,13 +105,13 @@ Create a playbook that invokes the installer role (the operator uses ansible-run
           cpu: 200m
           memory: 512Mi
     default_worker:
-      replicas: 1
+      replicas: 2
       resource_requirements:
         requests:
           cpu: 200m
           memory: 512Mi
     activation_worker:
-      replicas: 1
+      replicas: 3
       resource_requirements:
         requests:
           cpu: 200m

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -39,7 +39,7 @@ _api:
 
 default_worker: {}
 _default_worker:
-  replicas: 5
+  replicas: 2
   resource_requirements:
     requests:
       cpu: 25m


### PR DESCRIPTION
Follow-up to @kurokobo 's PR to add the default_worker group.  As discussed with @Alex-Izquierdo , this PR sets the default_worker's replicas to 2 by default.  

Related PR: 
* https://github.com/ansible/eda-server-operator/pull/118