### PR TITLE
fix: disable built-in scheduler in workers

### DIFF
--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -61,7 +61,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - aap-eda-manage rqworker --with-scheduler --worker-class aap_eda.core.tasking.ActivationWorker
+        - aap-eda-manage rqworker --worker-class aap_eda.core.tasking.ActivationWorker
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -61,7 +61,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - aap-eda-manage rqworker --with-scheduler --worker-class aap_eda.core.tasking.DefaultWorker
+        - aap-eda-manage rqworker --worker-class aap_eda.core.tasking.DefaultWorker
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'


### PR DESCRIPTION
Closes #120.

CR:

```yaml
---
apiVersion: eda.ansible.com/v1alpha1
kind: EDA
metadata:
  name: eda
spec:
  ...
  extra_settings:
    - setting: GIT_SSL_NO_VERIFY
      value: "true"

  api:
    replicas: 1
    resource_requirements:
      requests: {}
  ui:
    replicas: 1
    resource_requirements:
      requests: {}
  schedular:
    replicas: 1
    resource_requirements:
      requests: {}
  default_worker:
    replicas: 2
    resource_requirements:
      requests: {}
  activation_worker:
    replicas: 3
    resource_requirements:
      requests: {}
  ...
```

Results:

- All pods are up and running
- Web UI can be accessed
- Project canbe synched
- Three rulebooks can be activated at the same time since there are three activation workers

```bash
$ kubectl -n eda logs deployments/eda-server-operator-controller-manager | tail -n 9
----- Ansible Task Status Event StdOut (eda.ansible.com/v1alpha1, Kind=EDA, eda/eda) -----

PLAY RECAP *********************************************************************
localhost                  : ok=54   changed=0    unreachable=0    failed=0    skipped=16   rescued=0    ignored=0   

----------

$ kubectl -n eda get deployment
NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
eda-server-operator-controller-manager   1/1     1            1           111m
eda-redis                                1/1     1            1           110m
eda-ui                                   1/1     1            1           109m
eda-default-worker                       2/2     2            2           109m
eda-scheduler                            1/1     1            1           108m
eda-activation-worker                    3/3     3            3           109m
eda-api                                  1/1     1            1           109m

$ kubectl -n eda get deployment eda-default-worker -o jsonpath={.spec.template.spec.containers[0].args}
["/bin/bash","-c","aap-eda-manage rqworker --worker-class aap_eda.core.tasking.DefaultWorker"]

$ kubectl -n eda get deployment eda-activation-worker -o jsonpath={.spec.template.spec.containers[0].args}
["/bin/bash","-c","aap-eda-manage rqworker --worker-class aap_eda.core.tasking.ActivationWorker"]
```
