### PR TITLE
fix: update eda-ui to follow the latest changes

### DIFF
--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -57,6 +57,9 @@ spec:
       - name: eda-ui
         image: {{ _image_web }}
         imagePullPolicy: '{{ image_pull_policy }}'
+        envFrom:
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -74,15 +77,3 @@ spec:
 {% if combined_ui.resource_requirements is defined %}
         resources: {{ combined_ui.resource_requirements }}
 {% endif %}
-        volumeMounts:
-          - name: {{ ansible_operator_meta.name }}-nginx-conf
-            mountPath: /etc/nginx/nginx.conf
-            subPath: nginx.conf
-            readOnly: true
-      volumes:
-        - name: {{ ansible_operator_meta.name }}-nginx-conf
-          configMap:
-            name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
-            items:
-              - key: nginx_conf
-                path: nginx.conf

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -20,54 +20,10 @@ data:
   EDA_MQ_HOST: "{{ ansible_operator_meta.name }}-redis-svc"
   EDA_WEBSOCKET_BASE_URL: "ws://{{ websocket_server_name }}:8001"
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"
+  EDA_PROTOCOL: "http"
+  EDA_HOST: "{{ ansible_operator_meta.name }}-api:8000"
 
   # Custom user variables
 {% for item in extra_settings | default([]) %}
   {{ item.setting | upper }}: "{{ item.value }}"
 {% endfor %}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
-  namespace: '{{ ansible_operator_meta.namespace }}'
-  labels:
-    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
-data:
-  nginx_conf: |
-    events {
-        worker_connections 1024;
-    }
-    http {
-        include mime.types;
-        types {
-            application/manifest+json webmanifest;
-        }
-        server {
-            listen 8080 default_server;
-            listen [::]:8080;
-            server_name _;
-            server_tokens off;
-            root /opt/app-root/ui/eda;
-
-            location ~ ^/api/eda/v[0-9]+/ {
-                proxy_pass http://{{ ansible_operator_meta.name }}-api:8000;
-                proxy_set_header Host $http_host;
-                proxy_set_header X-Forwarded-Host $host;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header X-Forwarded-Port $server_port;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            }
-
-            location ~* \.(json|woff|woff2|jpe?g|png|gif|ico|svg|css|js)$ {
-                add_header Cache-Control "public, max-age=31536000, s-maxage=31536000, immutable";
-                try_files $uri =404;
-            }
-
-            location / {
-                expires 5m;
-                add_header Cache-Control "public";
-                try_files $uri $uri/ /index.html =404;
-            }
-        }
-    }


### PR DESCRIPTION
Closes #123 

This is the follow up PR for the update for eda-ui image: https://github.com/ansible/ansible-ui/pull/766

Changes:

- Remove configMap for `nginx.conf` and its referrences since the latest eda-ui can be configurable through environment variables 
- Add new environment variable `EDA_PROTOCOL` and `EDA_HOST` to `*-env-properties` and mount it on `eda-ui` container

Tested:

- Web UI can be accessed (`/`)
- API docs can be accessed (`/api/eda/v1/docs`)
- Project can be added