### PR TITLE
Set correct Redis data dir path for volume

### DIFF
--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - readOnly: false
-              mountPath: /data
+              mountPath: /var/lib/redis/data
               name: '{{ ansible_operator_meta.name }}-redis-data'
           ports:
             - protocol: TCP


### PR DESCRIPTION
The path mounted [in the volume for redis](https://github.com/ansible/eda-server-operator/blob/main/roles/redis/templates/redis.deployment.yaml.j2#L51) pod in the EDA controller operator is wrong. According to the source image it should be "/var/lib/redis/data" instead "/data".

Redis is being used only as a cache and data persistence is not a requirement, but it may be in the future, specially to recover workers activity across restarts/re-deployments, so it must be fixed at some point.


This PR corrects the path of the volume. 