### PR TITLE
Use sclorg redis c9s image instead of c8s

### DIFF
--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -6,7 +6,7 @@ deployment_type: eda
 image_pull_policy: IfNotPresent
 image_pull_secrets: []
 
-_redis_image: quay.io/sclorg/redis-6-c8s
+_redis_image: quay.io/sclorg/redis-6-c9s
 _redis_image_version: latest
 
 redis: {}


### PR DESCRIPTION
For consistency with awx-operator and postgres 15 image. 

Related:
* https://github.com/ansible/awx-operator/pull/1531