### PR TITLE
Improved debugging and better formatted operator logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
 COPY watches.yaml ${HOME}/watches.yaml
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
+
+COPY files/ansible.cfg /opt/ansible/roles/ansible.cfg

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -8,6 +8,33 @@ When the operator is deploying EDA, it is running the `eda` role inside the oper
 kubectl logs deployments/eda-server-operator-controller-manager -c eda-server-manager -f
 ```
 
+### Improving the Operator Logs
+
+To show more verbose logs, set the `ANSIBLE_VERBOSITY` env var to 2 (or higher) and `ANSIBLE_DEBUG_LOGS` to `true`. We have enabled the `yaml` stdout_callback in the operator's ansible.cfg, so this will now provide nicely formatted logs. You can do this easily with the following command.
+
+```
+kubectl set env deployment/eda-server-operator-controller-manager ANSIBLE_VERBOSITY=2
+```
+
+> Note: Setting verbosity to 3 is quite verbose, but may have more information to help with debugging in some cases.
+
+Furthermore, you can easily enable timing and performance metrics by copying in the ansible.cfg.dev config and rebuilding the operator image with it.
+
+```
+# Copy over custom ansible.cfg
+cp files/ansible.cfg.dev files/ansible.cfg
+
+# Build Operator image
+export QUAY_USER=youruser
+export TAG=dev
+make docker-build docker-push IMG=quay.io/$QUAY_USER/eda-server-operator:$TAG
+
+# Deploy
+export NAMESPACE=eda-dev
+make deploy IMG=quay.io/$QUAY_USER/eda-server-operator:$TAG NAMESPACE=$NAMESPACE
+
+```
+
 ### Inspect k8s Resources
 
 Past that, it is often useful to inspect various resources the EDA Operator manages like:

--- a/files/ansible.cfg
+++ b/files/ansible.cfg
@@ -1,0 +1,9 @@
+[defaults]
+roles_path = /opt/ansible/roles
+library = /usr/share/ansible/openshift
+callbacks_enabled = timer, profile_tasks, profile_roles
+stdout_callback = yaml
+callback_whitelist = profile_tasks, timer, profile_roles
+display_failed_stderr = True
+
+

--- a/files/ansible.cfg.dev
+++ b/files/ansible.cfg.dev
@@ -1,0 +1,9 @@
+[defaults]
+roles_path = /opt/ansible/roles
+library = /usr/share/ansible/openshift
+callbacks_enabled = timer, profile_tasks, profile_roles
+stdout_callback = yaml
+callback_whitelist = profile_tasks, timer, profile_roles
+display_failed_stderr = True
+
+


### PR DESCRIPTION
This lays the groundwork for building an ansible operator image with a custom ansible.cfg, which allows us to set things like `stdout_callback=yaml` for better formatted operator logs. 

From now on, the operator image will use yaml formatting if the log level is set high enough to merit it.  To set the log level:

```
kubectl set env deployment/eda-server-operator-controller-manager ANSIBLE_VERBOSITY=2
```

See docs added in this PR for setting a custom ansible.cfg for getting performance info.  Here is an example:


![image](https://github.com/ansible/eda-server-operator/assets/11698892/3ac42c9d-1cef-4600-8100-5647a7d04268)

