### PR TITLE
Explicitly set reconcile-period to avoid potential issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,8 @@ RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
 COPY watches.yaml ${HOME}/watches.yaml
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
+
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ansible-operator", "run", \
+     "--watches-file=./watches.yaml", \
+     "--reconcile-period=0s" \
+     ]


### PR DESCRIPTION
In the past, we had issues with the reconciliation loop never converging because the reconcile-period default change out from under us in an ansible-operator release.  This change makes eda-server-operator consistent with awx-operator in this regard.

* Context: https://github.com/ansible/awx-operator/pull/1001#issuecomment-1204188920