### PR TITLE
Add back the EDA_SERVER env var

### DIFF
--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -22,6 +22,7 @@ data:
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"
   EDA_PROTOCOL: "http"
   EDA_HOST: "{{ ansible_operator_meta.name }}-api:8000"
+  EDA_SERVER: "http://{{ ansible_operator_meta.name }}-api:8000"
 
   # Custom user variables
 {% for item in extra_settings | default([]) %}


### PR DESCRIPTION
Backstory here:
* https://github.com/ansible/eda-server/pull/412

But we are adding back the `EDA_SERVER` env var and in the future will remove `EDA_PROTOCOL` and `EDA_HOST` in the future.  Count them as deprecated for now.  