### PR TITLE
feat: disable https and allow disabling ipv6 on eda-ui

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2136,6 +2136,10 @@ spec:
               admin_password_secret:
                 description: Secret where the admin password can be found. If not specified, one will be generated.
                 type: string
+              ipv6_disabled:
+                description: Disable UI container's nginx ipv6 listener
+                type: boolean
+                default: false
           status:
             description: Status defines the observed state of EDA
             properties:

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -201,6 +201,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Disable IPv6 listener?
+        path: ipv6_disabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Name of the k8s secret the DB fields encryption key is stored
           in.
         displayName: DB Fields Encryption Key

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -145,3 +145,6 @@ db_fields_encryption_secret: ''
 admin_user: admin
 admin_email: test@example.com
 admin_password_secret: ''
+
+# Disable UI container's nginx ipv6 listener
+ipv6_disabled: false

--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -77,3 +77,15 @@ spec:
 {% if combined_ui.resource_requirements is defined %}
         resources: {{ combined_ui.resource_requirements }}
 {% endif %}
+        volumeMounts:
+          - name: {{ ansible_operator_meta.name }}-nginx-default-conf-template
+            mountPath: /etc/nginx/templates/default.conf.template
+            subPath: default.conf.template
+            readOnly: true
+      volumes:
+        - name: {{ ansible_operator_meta.name }}-nginx-default-conf-template
+          configMap:
+            name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+            items:
+              - key: nginx_default_conf_template
+                path: default.conf.template

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -28,3 +28,61 @@ data:
 {% for item in extra_settings | default([]) %}
   {{ item.setting | upper }}: "{{ item.value }}"
 {% endfor %}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+data:
+  nginx_default_conf_template: |
+    server {
+        listen 8080;
+        listen [::]:8080;
+
+        server_name _;
+        server_tokens off;
+
+        access_log off;
+        # error_log off;
+
+        autoindex off;
+
+        include mime.types;
+        types {
+            application/manifest+json webmanifest;
+        }
+
+        sendfile on;
+
+        root /usr/share/nginx/html;
+
+        location ~ ^/api/eda/v[0-9]+/ {
+            proxy_pass $EDA_SERVER;
+            proxy_set_header Origin $EDA_SERVER;
+        }
+
+        location ~ ^/api/eda/ws/[0-9a-z-]+ {
+            proxy_pass $EDA_SERVER;
+            proxy_set_header Origin $EDA_SERVER;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+        }
+
+        location ~* \.(json|woff|woff2|jpe?g|png|gif|ico|svg|css|js)$ {
+            add_header Cache-Control "public, max-age=31536000, s-maxage=31536000, immutable";
+            try_files $uri =404;
+            gzip_static on;
+        }
+
+        location / {
+            autoindex off;
+            expires off;
+            add_header Cache-Control "public, max-age=0, s-maxage=0, must-revalidate" always;
+            try_files $uri /index.html =404;
+        }
+    }

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -41,7 +41,9 @@ data:
   nginx_default_conf_template: |
     server {
         listen 8080;
+        {% if not ipv6_disabled %}
         listen [::]:8080;
+        {% endif %}
 
         server_name _;
         server_tokens off;


### PR DESCRIPTION
Closes #134, closes #135

In https://github.com/ansible/ansible-ui/pull/927, EDA UI was changed to listen on both HTTP (80) and HTTPS (443), and to redirect HTTP to HTTPS. However, in typical deployment, SSL termination on K8s is processed not on application container but on Ingress/Route, and implementing HTTPS passthrough on Ingress/Route require additional configuration.

This PR adds configmap to allow customize `default.conf` for Nginx, and stop listening HTTPS in eda-ui container.

Changes:

- Add configmap for `default.conf.template` for nginx and mount it on eda-ui
  - This file is based on [`eda.conf` on ansible-ui repo](https://github.com/ansible/ansible-ui/blob/89b16d74aaec7bffb027cf0655f15c16413e95d9/nginx/eda.conf) that used as `/etc/nginx/templates/default.conf.template` to generate `/etc/nginx/conf.d/default.conf` on its startup
  - Use 8080 for HTTP, and remove SSL related configuration
- Allow disabling IPv6 listener on eda-ui by `spec.ipv6_disabled` for EDA CR
  - As the same as AWX Operator

Tested:

- Web UI can be accessed (`/`)
- API docs can be accessed (`/api/eda/v1/docs`)
- Project can be added
- IPv6 listener is enabled by default
  ```bash
  $ kubectl -n eda exec -it deployment/eda-ui -- cat /etc/nginx/conf.d/default.conf
  server {
      listen 8080;
      listen [::]:8080;
  
      server_name _;
      server_tokens off;
  ...
  ```
- With `spec.ipv6_disabled: true`, IPv6 listener is disabled
  ```bash
  $ kubectl -n eda exec -it deployment/eda-ui -- cat /etc/nginx/conf.d/default.conf
  server {
      listen 8080;
      
      server_name _;
      server_tokens off;
  ...
  ```