### PR TITLE
ui: Do not use EDA_SERVER env variable

### DIFF
--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -67,8 +67,8 @@ data:
         }
 
         location ~ ^/api/eda/ws/[0-9a-z-]+ {
-            proxy_pass http://{{ ansible_operator_meta.name }}-api:8000;
-            proxy_set_header Origin http://{{ ansible_operator_meta.name }}-api:8000;
+            proxy_pass http://{{ ansible_operator_meta.name }}-daphne:8001;
+            proxy_set_header Origin http://{{ ansible_operator_meta.name }}-daphne:8001;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -22,7 +22,6 @@ data:
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"
   EDA_PROTOCOL: "http"
   EDA_HOST: "{{ ansible_operator_meta.name }}-api:8000"
-  EDA_SERVER: "http://{{ ansible_operator_meta.name }}-api:8000"
 
   # Custom user variables
 {% for item in extra_settings | default([]) %}
@@ -63,13 +62,13 @@ data:
         root /usr/share/nginx/html;
 
         location ~ ^/api/eda/v[0-9]+/ {
-            proxy_pass $EDA_SERVER;
-            proxy_set_header Origin $EDA_SERVER;
+            proxy_pass http://{{ ansible_operator_meta.name }}-api:8000;
+            proxy_set_header Origin http://{{ ansible_operator_meta.name }}-api:8000;
         }
 
         location ~ ^/api/eda/ws/[0-9a-z-]+ {
-            proxy_pass $EDA_SERVER;
-            proxy_set_header Origin $EDA_SERVER;
+            proxy_pass http://{{ ansible_operator_meta.name }}-api:8000;
+            proxy_set_header Origin http://{{ ansible_operator_meta.name }}-api:8000;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Not all EDA UI container images are using the environment variable
substitution from the entrypoint script.
This is only working for upstream eda-ui container image which is
based on alpine.

This image executes a script during the container start to: 
- subsitute environement variables (like `EDA_SERVER`)
- move the template file to the final destination.

```console
20-envsubst-on-templates.sh: Running envsubst on
/etc/nginx/templates/default.conf.template to /etc/nginx/conf.d/default.conf
```

All of those tasks can be done by the operator so there's no need
to rely on container image mechanism for this since it doesn't work
for another EDA UI container images.

Instead, we can just do the substitution of the `EDA_SERVER` value as part
of the eda-ui configmap template.
However, we can't bind mount the file as a regular file instead of a template
in /etc/nginx/conf.d instead of /etc/nginx/templates because the EDA UI
container image includes the default configuration file (which includes
the `EDA_SERVER` environment server).

This also fixes the websocket backend URL which wasn't using the daphne service with the correct port