### PR TITLE
ConfigMap a complete nginx.conf for the eda-server-operator

### DIFF
--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -79,8 +79,8 @@ spec:
 {% endif %}
         volumeMounts:
           - name: {{ ansible_operator_meta.name }}-nginx-default-conf-template
-            mountPath: /etc/nginx/templates/default.conf.template
-            subPath: default.conf.template
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
             readOnly: true
       volumes:
         - name: {{ ansible_operator_meta.name }}-nginx-default-conf-template
@@ -88,4 +88,4 @@ spec:
             name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
             items:
               - key: nginx_default_conf_template
-                path: default.conf.template
+                path: nginx.conf

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -22,7 +22,6 @@ data:
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"
   EDA_PROTOCOL: "http"
   EDA_HOST: "{{ ansible_operator_meta.name }}-api:8000"
-  EDA_SERVER: "http://{{ ansible_operator_meta.name }}-api:8000"
 
   # Custom user variables
 {% for item in extra_settings | default([]) %}
@@ -39,52 +38,61 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 data:
   nginx_default_conf_template: |
-    server {
-        listen 8080;
-        {% if not ipv6_disabled %}
-        listen [::]:8080;
-        {% endif %}
-
-        server_name _;
-        server_tokens off;
-
-        access_log off;
-        # error_log off;
-
-        autoindex off;
-
+    events {
+        worker_connections 1024;
+    }
+    http {
         include mime.types;
         types {
             application/manifest+json webmanifest;
         }
+        server {
+            listen 8080;
+            {% if not ipv6_disabled %}
+            listen [::]:8080;
+            {% endif %}
 
-        sendfile on;
+            server_name _;
+            server_tokens off;
 
-        root /usr/share/nginx/html;
+            access_log off;
+            # error_log off;
 
-        location ~ ^/api/eda/v[0-9]+/ {
-            proxy_pass $EDA_SERVER;
-            proxy_set_header Origin $EDA_SERVER;
-        }
-
-        location ~ ^/api/eda/ws/[0-9a-z-]+ {
-            proxy_pass $EDA_SERVER;
-            proxy_set_header Origin $EDA_SERVER;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "Upgrade";
-        }
-
-        location ~* \.(json|woff|woff2|jpe?g|png|gif|ico|svg|css|js)$ {
-            add_header Cache-Control "public, max-age=31536000, s-maxage=31536000, immutable";
-            try_files $uri =404;
-            gzip_static on;
-        }
-
-        location / {
             autoindex off;
-            expires off;
-            add_header Cache-Control "public, max-age=0, s-maxage=0, must-revalidate" always;
-            try_files $uri /index.html =404;
-        }
+
+            include mime.types;
+            types {
+                application/manifest+json webmanifest;
+            }
+
+            sendfile on;
+
+            root /usr/share/nginx/html;
+
+            location ~ ^/api/eda/v[0-9]+/ {
+                proxy_pass http://{{ ansible_operator_meta.name }}-api:8000;
+                proxy_set_header Origin http://{{ ansible_operator_meta.name }}-api:8000;
+            }
+
+            location ~ ^/api/eda/ws/[0-9a-z-]+ {
+                proxy_pass http://{{ ansible_operator_meta.name }}-daphne:8001;
+                proxy_set_header Origin http://{{ ansible_operator_meta.name }}-daphne:8001;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "Upgrade";
+            }
+
+            location ~* \.(json|woff|woff2|jpe?g|png|gif|ico|svg|css|js)$ {
+                add_header Cache-Control "public, max-age=31536000, s-maxage=31536000, immutable";
+                try_files $uri =404;
+                gzip_static on;
+            }
+
+            location / {
+                autoindex off;
+                expires off;
+                add_header Cache-Control "public, max-age=0, s-maxage=0, must-revalidate" always;
+                try_files $uri /index.html =404;
+            }
+          }
     }


### PR DESCRIPTION
This PR incorporates the changes in https://github.com/ansible/eda-server-operator/pull/140 as well.  Thanks @dsavineau for collaborating to make this PR happen!

We will now have a single EDA nginx.conf that includes everything needed and also templates in the api and daphne service names where needed.  