### PR TITLE
Configure Bundle CA Cert if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,66 +126,6 @@ yDL2Cx5Za94g9MvBP6B73nzVLlmfgPjR
 
 ## Advanced Configuration
 
-### Deploying a specific version of EDA
-
-There are a few variables that are customizable for eda the image management.
-
-| Name                   | Description               | Default                                 |
-| ---------------------- | ------------------------- | --------------------------------------  |
-| image                  | Path of the image to pull | quay.io/ansible/eda-server              |
-| image_version          | Image version to pull     | main                                    |
-| image_web              | Path of the image to pull | quay.io/ansible/eda-ui                  |
-| image_web_version      | Image version to pull     | latest                                  |
-| image_pull_policy      | The pull policy to adopt  | IfNotPresent                            |
-| image_pull_secrets     | The pull secrets to use   | None                                    |
-| redis_image            | Path of the image to pull | redis                                   |
-| redis_image_version    | Image version to pull     | latest                                  |
-| postgres_image         | Path of the image to pull | postgres                                |
-| postgres_image_version | Image version to pull     | latest                                  |
-
-Example of customization could be:
-
-```yaml
----
-spec:
-  ...
-  image: myorg/my-custom-eda
-  image_version: latest
-  image_web: myorg/my-custom-eda
-  image_web_version: latest
-  image_pull_policy: Always
-  image_pull_secrets:
-    - pull_secret_name
-```
-
-  > **Note**: The `image` and `image_version` style variables are intended for local mirroring scenarios. Please note that using a version of EDA other than the one bundled with the `eda-server-operator` is **not** supported even though it will likely work and can be useful for pinning a version. For the default values, check the [main.yml](https://github.com/ansible/eda-server-operator/blob/main/roles/eda/defaults/main.yml) file.
-
-
-### Configuring an image pull secret
-
-1. Log in with that token, or username/password, then create a pull secret from the docker/config.json
-
-```bash
-docker login quay.io -u <user> -p <token>
-```
-
-2. Then, create a k8s secret from your .docker/config.json file. This pull secret should be created in the same namespace you are installing the EDA Operator.
-
-```bash
-kubectl create secret generic redhat-operators-pull-secret \
-  --from-file=.dockerconfigjson=.docker/config.json \
-  --type=kubernetes.io/dockerconfigjson
-```
-
-3. Add that image pull secret to your EDA spec
-
-```yaml
----
-spec:
-  image_pull_secrets:
-    - redhat-operators-pull-secret
-```
-
 ### Admin user account configuration
 
 There are three variables that are customizable for the admin user account creation.
@@ -236,17 +176,22 @@ The secret should be formatted as follow:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: custom-awx-db-encryption-secret
+  name: custom-eda-db-encryption-secret
   namespace: <target namespace>
 stringData:
   secret_key: supersecuresecretkey
 ```
 
-Then specify the name of the k8s secret on the AWX spec:
+Then specify the name of the k8s secret on the EDA spec:
 
 ```yaml
 ---
 spec:
   ...
-  db_fields_encryption_secret: custom-awx-db-encryption-secret
+  db_fields_encryption_secret: custom-eda-db-encryption-secret
 ```
+
+### Additional Advanced Configuration
+- [No Log](./docs/user-guide/advanced-configuration/no-log.md)
+- [Deploy a Specific Version of EDA](./docs/user-guide/advanced-configuration/deploying-a-specific-version.md)
+- [Trusting a Custom Certificate Authority](./docs/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md)

--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2140,6 +2140,9 @@ spec:
                 description: Disable UI container's nginx ipv6 listener
                 type: boolean
                 default: false
+              bundle_cacert_secret:
+                description: Secret where can be found the trusted Certificate Authority Bundle
+                type: string
           status:
             description: Status defines the observed state of EDA
             properties:

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -633,6 +633,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:NodePort
+      - description: Secret where can be found the trusted Certificate Authority Bundle
+        path: bundle_cacert_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
       - displayName: Service Account Annotations
         path: service_account_annotations
         x-descriptors:

--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version.md
@@ -1,0 +1,59 @@
+## Deploying a specific version of EDA
+
+There are a few variables that are customizable for eda the image management.
+
+| Name                   | Description               | Default                                 |
+| ---------------------- | ------------------------- | --------------------------------------  |
+| image                  | Path of the image to pull | quay.io/ansible/eda-server              |
+| image_version          | Image version to pull     | latest                                  |
+| image_web              | Path of the image to pull | quay.io/ansible/eda-ui                  |
+| image_web_version      | Image version to pull     | latest                                  |
+| image_pull_policy      | The pull policy to adopt  | IfNotPresent                            |
+| image_pull_secrets     | The pull secrets to use   | None                                    |
+| redis_image            | Path of the image to pull | redis                                   |
+| redis_image_version    | Image version to pull     | latest                                  |
+| postgres_image         | Path of the image to pull | postgres                                |
+| postgres_image_version | Image version to pull     | latest                                  |
+
+Example of customization could be:
+
+```yaml
+---
+spec:
+  ...
+  image: myorg/my-custom-eda
+  image_version: latest
+  image_web: myorg/my-custom-eda
+  image_web_version: latest
+  image_pull_policy: Always
+  image_pull_secrets:
+    - pull_secret_name
+```
+
+  > **Note**: The `image` and `image_version` style variables are intended for local mirroring scenarios. Please note that using a version of EDA other than the one bundled with the `eda-server-operator` is **not** supported even though it will likely work and can be useful for pinning a version. For the default values, check the [main.yml](https://github.com/ansible/eda-server-operator/blob/main/roles/eda/defaults/main.yml) file.
+
+
+### Configuring an image pull secret
+
+1. Log in with that token, or username/password, then create a pull secret from the docker/config.json
+
+```bash
+docker login quay.io -u <user> -p <token>
+```
+
+2. Then, create a k8s secret from your .docker/config.json file. This pull secret should be created in the same namespace you are installing the EDA Operator.
+
+```bash
+kubectl create secret generic redhat-operators-pull-secret \
+  --from-file=.dockerconfigjson=.docker/config.json \
+  --type=kubernetes.io/dockerconfigjson
+```
+
+3. Add that image pull secret to your EDA spec
+
+```yaml
+---
+spec:
+  image_pull_secrets:
+    - redhat-operators-pull-secret
+```

--- a/docs/user-guide/advanced-configuration/no-log.md
+++ b/docs/user-guide/advanced-configuration/no-log.md
@@ -1,0 +1,14 @@
+## No Log
+
+Configure no_log for tasks with no_log
+
+| Name   | Description          | Default |
+| ------ | -------------------- | ------- |
+| no_log | No log configuration | 'true'  |
+
+Example configuration of `no_log` parameter
+
+```yaml
+  spec:
+    no_log: true
+```

--- a/docs/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md
+++ b/docs/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md
@@ -1,0 +1,51 @@
+## Trusting a Custom Certificate Authority
+
+In cases which you need to trust a custom Certificate Authority, there are few variables you can customize for the `eda-server-operator`.
+
+Trusting a custom Certificate Authority allows the EDA to access network services configured with SSL certificates issued locally, such as cloning a project from from an internal Git server via HTTPS. If it is needed, you will likely see errors like this when doing project syncs:
+
+```bash
+fatal: unable to access 'https://private.repo./mine/ansible-rulebook.git': SSL certificate problem: unable to get local issuer certificate
+```
+
+
+| Name                             | Description                              | Default |
+| -------------------------------- | ---------------------------------------- | --------|
+| bundle_cacert_secret             | Certificate Authority secret name        |  ''     |
+Please note the `eda-server-operator` will look for the data field `ldap-ca.crt` in the specified secret when using the `ldap_cacert_secret`, whereas the data field `bundle-ca.crt` is required for `bundle_cacert_secret` parameter.
+
+Example of customization could be:
+
+```yaml
+---
+spec:
+  ...
+  bundle_cacert_secret: <resourcename>-custom-certs
+```
+
+Create the secret with CLI:
+
+* Certificate Authority secret
+
+```
+# kubectl create secret generic <resourcename>-custom-certs \
+    --from-file=ldap-ca.crt=<PATH/TO/YOUR/CA/PEM/FILE>  \
+    --from-file=bundle-ca.crt=<PATH/TO/YOUR/CA/PEM/FILE>
+```
+
+
+Alternatively, you can also create the secret with `kustomization.yaml` file:
+
+```yaml
+....
+
+secretGenerator:
+  - name: <resourcename>-custom-certs
+    files:
+      - bundle-ca.crt=<path+filename>
+    options:
+      disableNameSuffixHash: true
+      
+...
+```
+

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -11,7 +11,7 @@ image_pull_policy: IfNotPresent
 image_pull_secrets: []
 
 _image: quay.io/ansible/eda-server
-_image_version: main
+_image_version: latest
 
 _image_web: quay.io/ansible/eda-ui
 _image_web_version: latest

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -138,6 +138,9 @@ route_host: ''
 
 hostname: ''
 
+# Secret to lookup that provides the custom CA trusted bundle
+bundle_cacert_secret: ''
+
 # Secret to lookup that provide the secret key
 # #
 db_fields_encryption_secret: ''

--- a/roles/eda/tasks/main.yml
+++ b/roles/eda/tasks/main.yml
@@ -19,6 +19,11 @@
 - name: Set EDA app images
   include_tasks: set_images.yml
 
+- name: Set Bundle Certificate Authority
+  include_tasks: set_bundle_cacert.yml
+  when:
+  - bundle_cacert_secret | length
+
 - name: Create DB fields encryption
   include_tasks: db_fields_encryption_configuration.yml
 

--- a/roles/eda/tasks/set_bundle_cacert.yml
+++ b/roles/eda/tasks/set_bundle_cacert.yml
@@ -1,0 +1,14 @@
+---
+- name: Retrieve bundle Certificate Authority Secret
+  k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ bundle_cacert_secret }}'
+  register: bundle_cacert
+  no_log: "{{ no_log }}"
+
+- name: Load bundle Certificate Authority Secret content
+  set_fact:
+    bundle_ca_crt: '{{ bundle_cacert["resources"][0]["data"]["bundle-ca.crt"] | b64decode }}'
+  no_log: "{{ no_log }}"
+  when: '"bundle-ca.crt" in bundle_cacert["resources"][0]["data"]'

--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -54,6 +54,28 @@ spec:
       topologySpreadConstraints:
         {{ combined_activation_worker.topology_spread_constraints | indent(width=8) }}
 {% endif %}
+{% if bundle_ca_crt  %}
+      initContainers:
+      - name: configure-bundle-ca-cert
+        image: {{ _image }}
+        imagePullPolicy: '{{ image_pull_policy }}'
+        command:
+          - /bin/sh
+          - -c
+          - |
+            mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
+            update-ca-trust
+{% if combined_api.resource_requirements is defined %}
+        resources: {{ combined_activation_worker.resource_requirements }}
+{% endif %}
+        volumeMounts:
+          - name: "ca-trust-extracted"
+            mountPath: "/etc/pki/ca-trust/extracted"
+          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            subPath: bundle-ca.crt
+            readOnly: true
+{% endif %}
       containers:
       - name: eda-activation-worker
         image: {{ _image }}
@@ -104,7 +126,25 @@ spec:
         volumeMounts:
           - name: "{{ ansible_operator_meta.name }}-media-data"
             mountPath: "{{ media_dir }}"
+{% if bundle_ca_crt %}
+          - name: "ca-trust-extracted"
+            mountPath: "/etc/pki/ca-trust/extracted"
+          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            subPath: bundle-ca.crt
+            readOnly: true
+{% endif %}
       restartPolicy: Always
       volumes:
         - name: {{ ansible_operator_meta.name }}-media-data
           emptyDir: {}
+{% if bundle_ca_crt %}
+        - name: "ca-trust-extracted"
+          emptyDir: {}
+        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+          secret:
+            secretName: "{{ bundle_cacert_secret }}"
+            items:
+              - key: bundle-ca.crt
+                path: 'bundle-ca.crt'
+{% endif %}

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -137,6 +137,27 @@ spec:
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}
+{% if bundle_ca_crt  %}
+      - name: configure-bundle-ca-cert
+        image: {{ _image }}
+        imagePullPolicy: '{{ image_pull_policy }}'
+        command:
+          - /bin/sh
+          - -c
+          - |
+            mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
+            update-ca-trust
+{% if combined_api.resource_requirements is defined %}
+        resources: {{ combined_api.resource_requirements }}
+{% endif %}
+        volumeMounts:
+          - name: "ca-trust-extracted"
+            mountPath: "/etc/pki/ca-trust/extracted"
+          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            subPath: bundle-ca.crt
+            readOnly: true
+{% endif %}
       containers:
       - name: eda-api
         image: {{ _image }}
@@ -242,4 +263,24 @@ spec:
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}
+{% if bundle_ca_crt %}
+        volumeMounts:
+          - name: "ca-trust-extracted"
+            mountPath: "/etc/pki/ca-trust/extracted"
+          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            subPath: bundle-ca.crt
+            readOnly: true
+{% endif %}
       restartPolicy: Always
+{% if bundle_ca_crt %}
+      volumes:
+        - name: "ca-trust-extracted"
+          emptyDir: {}
+        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+          secret:
+            secretName: "{{ bundle_cacert_secret }}"
+            items:
+              - key: bundle-ca.crt
+                path: 'bundle-ca.crt'
+{% endif %}

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -54,6 +54,28 @@ spec:
       topologySpreadConstraints:
         {{ combined_default_worker.topology_spread_constraints | indent(width=8) }}
 {% endif %}
+{% if bundle_ca_crt  %}
+      initContainers:
+      - name: configure-bundle-ca-cert
+        image: {{ _image }}
+        imagePullPolicy: '{{ image_pull_policy }}'
+        command:
+          - /bin/sh
+          - -c
+          - |
+            mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
+            update-ca-trust
+{% if combined_api.resource_requirements is defined %}
+        resources: {{ combined_default_worker.resource_requirements }}
+{% endif %}
+        volumeMounts:
+          - name: "ca-trust-extracted"
+            mountPath: "/etc/pki/ca-trust/extracted"
+          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            subPath: bundle-ca.crt
+            readOnly: true
+{% endif %}
       containers:
       - name: eda-default-worker
         image: {{ _image }}
@@ -104,7 +126,25 @@ spec:
         volumeMounts:
           - name: "{{ ansible_operator_meta.name }}-media-data"
             mountPath: "{{ media_dir }}"
+{% if bundle_ca_crt %}
+          - name: "ca-trust-extracted"
+            mountPath: "/etc/pki/ca-trust/extracted"
+          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            subPath: bundle-ca.crt
+            readOnly: true
+{% endif %}
       restartPolicy: Always
       volumes:
         - name: {{ ansible_operator_meta.name }}-media-data
           emptyDir: {}
+{% if bundle_ca_crt %}
+        - name: "ca-trust-extracted"
+          emptyDir: {}
+        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+          secret:
+            secretName: "{{ bundle_cacert_secret }}"
+            items:
+              - key: bundle-ca.crt
+                path: 'bundle-ca.crt'
+{% endif %}

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -11,7 +11,7 @@ data:
   # Operator specific settings
   EDA_DEPLOYMENT_TYPE: "k8s"
 
-  # AWX Server
+  # EDA Server
   EDA_CONTROLLER_URL: "{{ automation_server_url }}"
   EDA_CONTROLLER_SSL_VERIFY: "{{ automation_server_ssl_verify | default('yes')}}"
 

--- a/roles/eda/vars/main.yml
+++ b/roles/eda/vars/main.yml
@@ -3,3 +3,4 @@
 
 websocket_server_name: "{{ ansible_operator_meta.name }}-daphne"
 media_dir: /var/lib/eda/files
+bundle_ca_crt: ''


### PR DESCRIPTION
## Summary

When deploying EDA into an environment where a private Git server is in use with private CA-signed certificates in front of it, EDA worker pods fail to `git clone...` when Git projects are defined.

The awx-operator allows for private CA-signed certs via the bundle_cacert_secret property in the AutomationController CRD.  This PR adopts the same pattern for the EDA-server-operator.



### Docs for Trusting a Custom Certificate Authority

In cases which you need to trust a custom Certificate Authority, there are few variables you can customize for the `awx-operator`.

Trusting a custom Certificate Authority allows the EDA to access network services configured with SSL certificates issued locally, such as cloning a project from from an internal Git server via HTTPS. It is common for these scenarios, experiencing the error [unable to verify the first certificate](https://github.com/ansible/awx-operator/issues/376).


Please note the `eda-server-operator` will look for the data field `ldap-ca.crt` in the specified secret when using the `ldap_cacert_secret`, whereas the data field `bundle-ca.crt` is required for `bundle_cacert_secret` parameter.

Example of customization could be:

```yaml
---
spec:
  ...
  bundle_cacert_secret: <resourcename>-custom-certs
```


Create the secret with CLI:

* Certificate Authority secret

```
# kubectl create secret generic <resourcename>-custom-certs \
    --from-file=ldap-ca.crt=<PATH/TO/YOUR/CA/PEM/FILE>  \
    --from-file=bundle-ca.crt=<PATH/TO/YOUR/CA/PEM/FILE>
```