### PR TITLE
Fix wording for CA Bundle displayName

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2141,7 +2141,7 @@ spec:
                 type: boolean
                 default: false
               bundle_cacert_secret:
-                description: Secret where can be found the trusted Certificate Authority Bundle
+                description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string
           status:
             description: Status defines the observed state of EDA

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -523,8 +523,8 @@ spec:
         path: redis.node_selector
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Deployment strategy to use to replace existing pods with
-          new ones.
+      - description: Deployment strategy to use to replace existing pods with new
+          ones.
         displayName: Strategy
         path: redis.strategy
         x-descriptors:
@@ -633,7 +633,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:NodePort
-      - description: Secret where can be found the trusted Certificate Authority Bundle
+      - description: Secret where the trusted Certificate Authority Bundle is stored
         path: bundle_cacert_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced


### PR DESCRIPTION
This just makes the wording clearer for the CA Bundle displayName.  It also adds in a small formatting change so that there is no diff when running `make bundle`.  