### PR TITLE
Use valid combined_ settings references

### DIFF
--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -65,7 +65,7 @@ spec:
           - |
             mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
             update-ca-trust
-{% if combined_api.resource_requirements is defined %}
+{% if combined_activation_worker.resource_requirements is defined %}
         resources: {{ combined_activation_worker.resource_requirements }}
 {% endif %}
         volumeMounts:

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -65,7 +65,7 @@ spec:
           - |
             mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
             update-ca-trust
-{% if combined_api.resource_requirements is defined %}
+{% if combined_default_worker.resource_requirements is defined %}
         resources: {{ combined_default_worker.resource_requirements }}
 {% endif %}
         volumeMounts:

--- a/roles/eda/templates/eda-scheduler.deployment.yaml.j2
+++ b/roles/eda/templates/eda-scheduler.deployment.yaml.j2
@@ -93,8 +93,8 @@ spec:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
-{% if combined_worker.resource_requirements is defined %}
-        resources: {{ combined_worker.resource_requirements }}
+{% if combined_scheduler.resource_requirements is defined %}
+        resources: {{ combined_scheduler.resource_requirements }}
 {% endif %}
 
       restartPolicy: Always


### PR DESCRIPTION
There were a few examples where `combined_api` and `combined_default_worker` were mixed up, etc.  This sets them straight.  