### PR TITLE
Exclude unneeded websocket daphne section of nginx conf

### DIFF
--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -79,20 +79,6 @@ data:
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             }
 
-            location ~ ^/api/eda/ws/[0-9a-z-]+ {
-                proxy_pass http://{{ ansible_operator_meta.name }}-daphne:8001;
-                proxy_set_header Origin http://{{ ansible_operator_meta.name }}-daphne:8001;
-                proxy_set_header Host $http_host;
-                proxy_set_header X-Forwarded-Host $host;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header X-Forwarded-Port $server_port;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-                proxy_http_version 1.1;
-                proxy_set_header Upgrade $http_upgrade;
-                proxy_set_header Connection "Upgrade";
-            }
-
             location ~* \.(json|woff|woff2|jpe?g|png|gif|ico|svg|css|js)$ {
                 add_header Cache-Control "public, max-age=31536000, s-maxage=31536000, immutable";
                 try_files $uri =404;


### PR DESCRIPTION
- workers talk to daphne directly, rather than going through nginx

This earlier PR got reverted mistakenly when the nginx config was added back:
* https://github.com/ansible/eda-server-operator/pull/83