### PR TITLE
fix: trust internal origin for eda-api

### DIFF
--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -17,6 +17,7 @@ data:
 
   # EDA Server
   EDA_ALLOWED_HOSTS: "['*']"
+  EDA_CSRF_TRUSTED_ORIGINS: "http://{{ ansible_operator_meta.name }}-api:8000"
   EDA_MQ_HOST: "{{ ansible_operator_meta.name }}-redis-svc"
   EDA_WEBSOCKET_BASE_URL: "ws://{{ websocket_server_name }}:8001"
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"


### PR DESCRIPTION
Closes #148 

### Changes

- Add `EDA_CSRF_TRUSTED_ORIGINS` to ConfigMap to trust internal origin for eda-api

### Tests

Deployed following EDA (without any `extra_settings`) and confirmed that the user can login to UI:

```yaml
  image: quay.io/ansible/eda-server
  image_version: sha-70529ad

  image_web: quay.io/ansible/eda-ui
  image_web_version: 2.4.716
```

`eda-api` has env as expected:

```bash
$ kubectl -n eda exec -it deployment/eda-api -- env | grep CSRF
EDA_CSRF_TRUSTED_ORIGINS=http://eda-api:8000
```

No `WARNING` for `django.security.csrf` in the logs.