### PR TITLE
eda: Remove legacy worker deployment

### DIFF
--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -20,6 +20,14 @@
     - 'eda-activation-worker.deployment'
     - 'eda-scheduler.deployment'
 
+- name: Remove legacy EDA worker deployment
+  k8s:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}-worker"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+
 - name: Check for API Pod
   k8s_info:
     kind: Pod


### PR DESCRIPTION
075318e introduced new worker deployments (default and activation) but the old worker deployment was still present.
Trying to upgrade from EDA 1.0.1 deployment to a more recent version that includes the worker changes will left the legacy worker deployment. This is causing issues when EDA tries to schedule new activations after the upgrade.