### PR TITLE
Redirect traffic to eda/ urlpath in nginx config

### DIFF
--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -64,13 +64,13 @@ spec:
         - containerPort: 8080
         readinessProbe:
           httpGet:
-            path: /
+            path: /eda/
             port: 8080
           failureThreshold: 1
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /
+            path: /eda/
             port: 8080
           failureThreshold: 1
           periodSeconds: 10

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -87,10 +87,15 @@ data:
             }
 
             location / {
+                # Redirect all traffic from root to /eda/
+                return 301 $scheme://$host/eda/;
+            }
+
+            location /eda/ {
                 autoindex off;
                 expires off;
                 add_header Cache-Control "public, max-age=0, s-maxage=0, must-revalidate" always;
-                try_files $uri /index.html =404;
+                try_files $uri $uri/ /index.html =404;
             }
-          }
-    }
+        }
+      }


### PR DESCRIPTION
Closes: https://github.com/ansible/eda-server-operator/issues/153

The eda-ui container now serves up the static files at the /eda/ path, the operator's nginx.conf configmap needs to be updated to reflect this, otherwise the UI shows as blank.  

I also added a bit to redirect `/eda` --> `/eda/`, without it, users may see a 404.  

cc @kurokobo as you have probably seen this issue. 