### PR TITLE
Use $remote_scheme to correctly set the HTTP protocol the client is used

### DIFF
--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -43,6 +43,11 @@ data:
         worker_connections 1024;
     }
     http {
+        map $http_x_forwarded_proto $remote_scheme {
+            default $http_x_forwarded_proto;
+            ''      $scheme;
+        }
+
         include mime.types;
         types {
             application/manifest+json webmanifest;
@@ -75,7 +80,7 @@ data:
                 proxy_set_header Origin http://{{ ansible_operator_meta.name }}-api:8000;
                 proxy_set_header Host $http_host;
                 proxy_set_header X-Forwarded-Host $host;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $remote_scheme;
                 proxy_set_header X-Forwarded-Port $server_port;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             }
@@ -88,7 +93,7 @@ data:
 
             location / {
                 # Redirect all traffic from root to /eda/
-                return 301 $scheme://$host/eda/;
+                return 301 $remote_scheme://$host/eda/;
             }
 
             location /eda/ {


### PR DESCRIPTION
Resolves: https://github.com/ansible/eda-server-operator/issues/155

This PR modifies the nginx configmap to use $remote_scheme to correctly set the HTTP protocol the client is used.

cc @kurokobo 