### PR TITLE
Increase how long we wait for the api pod to come up

### DIFF
--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -44,6 +44,9 @@
     - "eda_api_pod['resources'] | length"
     - "eda_api_pod['resources'][0]['status']['phase'] == 'Running'"
     - "eda_api_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
+    - "eda_api_pod['resources'][0]['status']['containerStatuses'][1]['ready'] == true"
+  retries: 60
+  delay: 5
 
 - name: Set the resource pod name as a variable.
   set_fact:

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -208,14 +208,14 @@ spec:
             port: 8000
           failureThreshold: 10
           periodSeconds: 10
-          initialDelaySeconds: 90
+          initialDelaySeconds: 20
         livenessProbe:
           httpGet:
             path: /_healthz
             port: 8000
           failureThreshold: 10
           periodSeconds: 10
-          initialDelaySeconds: 90
+          initialDelaySeconds: 20
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}


### PR DESCRIPTION
Resolves: https://github.com/ansible/eda-server-operator/issues/154

This PR increases how long we wait for the api pod to come up
- There are 3 initContainers and migrations that need to run before the API pod is in the running state, this is expected to take a bit of time.
- This will avoid the reconciliation loop failing when checking the API pod (default was only 15 seconds prior to this change).

cc @kurokobo 