### PR TITLE
Enable multi-arch builds in GHA for the main branch

### DIFF
--- a/.github/workflows/build-operator-image.yaml
+++ b/.github/workflows/build-operator-image.yaml
@@ -13,16 +13,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v1
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
-          registry: quay.io
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log into registry quay.io
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: quay.io/ansible/
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
-      - name: Build and Push Image
+      - name: Build and Store Image @ghcr
         run: |
-          IMG=quay.io/ansible/eda-server-operator:main make docker-buildx
+          IMG=ghcr.io/${{ github.repository_owner }}/eda-server-operator:${{ github.sha }} make docker-buildx
+
+      - name: Publish Image to quay.io/ansible/eda-server-operator:main
+        run: |
+          docker buildx imagetools create ghcr.io/${{ github.repository_owner }}/eda-server-operator:${{ github.sha }} --tag quay.io/ansible/eda-server-operator:main

--- a/.github/workflows/build-operator-image.yaml
+++ b/.github/workflows/build-operator-image.yaml
@@ -13,15 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build Image
-        run: |
-          IMG=eda-server-operator:main make docker-build
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Push To Quay
-        uses: redhat-actions/push-to-registry@v2.1.1
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
         with:
-          image: eda-server-operator
-          tags: main
-          registry: quay.io/ansible/
+          registry: quay.io
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Build and Push Image
+        run: |
+          IMG=quay.io/ansible/eda-server-operator:main make docker-buildx


### PR DESCRIPTION
We should build multi-arch images for the eda-server-operator, starting with the the images built for the `main` branch. 


Example of a successful run on my fork:
* https://github.com/rooftopcellist/eda-server-operator/actions/runs/7442607946/job/20246278257