### PR TITLE
Set default tags for eda-server and eda-ui images

### DIFF
--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version.md
@@ -22,9 +22,9 @@ Example of customization could be:
 spec:
   ...
   image: myorg/my-custom-eda
-  image_version: latest
+  image_version: main
   image_web: myorg/my-custom-eda
-  image_web_version: latest
+  image_web_version: main
   image_pull_policy: Always
   image_pull_secrets:
     - pull_secret_name

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -11,10 +11,10 @@ image_pull_policy: IfNotPresent
 image_pull_secrets: []
 
 _image: quay.io/ansible/eda-server
-_image_version: latest
+_image_version: main
 
 _image_web: quay.io/ansible/eda-ui
-_image_web_version: latest
+_image_web_version: main
 
 # Add a nodeSelector for the EDA pods. It must match a node's labels for the pod
 # to be scheduled on that node. Specify as literal block. E.g.:


### PR DESCRIPTION
It was pointed out in the following comment that the default image tag for eda-server was invalid:
* https://github.com/ansible/eda-server-operator/issues/125#issuecomment-1870375961

I hadn't realized because my test EDA CR specified the `main` image.  This PR updates the default image tags and the doc examples.  The eda-ui image uses the `main` tag as well (alias of `latest` in that registry), so I switched that one as well for consistency.  