### PR TITLE
route: Load TLS secret

### DIFF
--- a/roles/eda/tasks/load_route_tls_secret.yml
+++ b/roles/eda/tasks/load_route_tls_secret.yml
@@ -1,0 +1,21 @@
+---
+- name: Retrieve Route TLS Secret
+  k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ route_tls_secret }}'
+  register: route_tls
+  no_log: "{{ no_log }}"
+
+- name: Load Route TLS Secret content
+  set_fact:
+    route_tls_key: '{{ route_tls["resources"][0]["data"]["tls.key"] | b64decode }}'
+    route_tls_crt: '{{ route_tls["resources"][0]["data"]["tls.crt"] | b64decode }}'
+  no_log: "{{ no_log }}"
+
+- name: Load Route TLS Secret content
+  set_fact:
+    route_ca_crt: '{{ route_tls["resources"][0]["data"]["ca.crt"] | b64decode }}'
+  no_log: "{{ no_log }}"
+  when: '"ca.crt" in route_tls["resources"][0]["data"]'
+...

--- a/roles/eda/tasks/main.yml
+++ b/roles/eda/tasks/main.yml
@@ -30,6 +30,12 @@
 - name: Create admin password
   include_tasks: admin_password_configuration.yml
 
+- name: Load Route TLS certificate
+  include_tasks: load_route_tls_secret.yml
+  when:
+    - ingress_type | lower == 'route'
+    - route_tls_secret | length
+
 - name: Deploy EDA
   include_tasks: deploy_eda.yml
 


### PR DESCRIPTION
When using route with edge TLS termination mechanism then the content of the TLS secret (tls.crt and tls.key) aren't loaded as facts so the route resource fails to be created.

Fixes: #160