### PR TITLE
feat: bump kustomize version to 5.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ifeq (,$(shell which kustomize 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(KUSTOMIZE)) ;\
-	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.7/kustomize_v4.5.7_$(OS)_$(ARCH).tar.gz | \
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.3.0/kustomize_v5.3.0_$(OS)_$(ARCH).tar.gz | \
 	tar xzf - -C bin/ ;\
 	}
 else

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,10 +21,10 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
-
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: manager_auth_proxy_patch.yaml

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -7,10 +7,6 @@ namePrefix: osdk-
 #commonLabels:
 #  someName: someValue
 
-patchesStrategicMerge:
-- manager_image.yaml
-- debug_logs_patch.yaml
-- ../default/manager_auth_proxy_patch.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -21,3 +17,7 @@ resources:
 images:
 - name: testing
   newName: testing-operator
+patches:
+- path: manager_image.yaml
+- path: debug_logs_patch.yaml
+- path: ../default/manager_auth_proxy_patch.yaml


### PR DESCRIPTION
Closes #165 

As suggested in the deprecated message, `kustomize edit fix` was applied to `config/manager` (no changes), `config/default`, and `config/testing`.

Tested to ensure `5.3.0` of `kustomize` is used and no warning message is displayed.

```bash
# Ensure no existing kustomize binary in path
$ which kustomize
/usr/bin/which: no kustomize in (...)

# Ensure Operator can be deployed without any warning messages
$ NAMESPACE=eda VERSION=latest make deploy
cd config/manager && /.../eda-server-operator/bin/kustomize edit set image controller=quay.io/ansible/eda-server-operator:latest
cd config/default && /.../eda-server-operator/bin/kustomize edit set namespace eda
/.../eda-server-operator/bin/kustomize build config/default | kubectl apply -f -
namespace/eda created
customresourcedefinition.apiextensions.k8s.io/edabackups.eda.ansible.com created
customresourcedefinition.apiextensions.k8s.io/edarestores.eda.ansible.com created
customresourcedefinition.apiextensions.k8s.io/edas.eda.ansible.com created
serviceaccount/eda-server-operator-controller-manager created
role.rbac.authorization.k8s.io/eda-server-operator-eda-manager-role created
role.rbac.authorization.k8s.io/eda-server-operator-leader-election-role created
clusterrole.rbac.authorization.k8s.io/eda-server-operator-metrics-reader created
clusterrole.rbac.authorization.k8s.io/eda-server-operator-proxy-role created
rolebinding.rbac.authorization.k8s.io/eda-server-operator-eda-manager-rolebinding created
rolebinding.rbac.authorization.k8s.io/eda-server-operator-leader-election-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/eda-server-operator-proxy-rolebinding created
service/eda-server-operator-controller-manager-metrics-service created
deployment.apps/eda-server-operator-controller-manager created

# Ensure newer kustomize was downloaded
$ ./bin/kustomize version
v5.3.0
```

Also tested to ensure there is no difference between `operator.yaml` that generated via `make generate-operator-yaml`

```bash
# Generate operator.yaml by kustomize 4.5.7
## checkout main branch
$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

## remove existing kustomize
$ rm bin/kustomize 

## generate operaotr.yaml
$ VERSION=latest make generate-operator-yaml
Generated operator.yaml with image tag latest

## ensure kustomize 4.5.7 was downloaded
$ bin/kustomize version
{Version:kustomize/v4.5.7 GitCommit:56d82a8378dfc8dc3b3b1085e5a6e67b82966bd7 BuildDate:2022-08-02T16:35:54Z GoOs:linux GoArch:amd64}

## rename generated file
$ mv operator.yaml operator.4.5.7.yaml 

## revert changes made by make
$ git checkout .
Updated 1 path from the index


# Generate operator.yaml by kustomize 5.3.0
## checkout this PR
$ git checkout kustomize
Switched to branch 'kustomize'

## remove existing kustomize
$ rm bin/kustomize 
$ VERSION=latest make generate-operator-yaml
Generated operator.yaml with image tag latest

## ensure kustomize 5.3.0 was downloaded
$ bin/kustomize version
v5.3.0

## rename generated file
$ mv operator.yaml operator.5.3.0.yaml


# Ensure there is no difference
$ diff operator.4.5.7.yaml operator.5.3.0.yaml 
$ sha256sum operator.*.yaml
aff6c1cb6b5200909b1a1557a2f02c424adccad618c3ebcfad8230047d20b0f0  operator.4.5.7.yaml
aff6c1cb6b5200909b1a1557a2f02c424adccad618c3ebcfad8230047d20b0f0  operator.5.3.0.yaml
```