### PR TITLE
Remove unneeded redirect to /eda

### DIFF
--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -64,13 +64,13 @@ spec:
         - containerPort: 8080
         readinessProbe:
           httpGet:
-            path: /eda/
+            path: /
             port: 8080
           failureThreshold: 1
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /eda/
+            path: /
             port: 8080
           failureThreshold: 1
           periodSeconds: 10

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -92,11 +92,6 @@ data:
             }
 
             location / {
-                # Redirect all traffic from root to /eda/
-                return 301 $remote_scheme://$host/eda/;
-            }
-
-            location /eda/ {
                 autoindex off;
                 expires off;
                 add_header Cache-Control "public, max-age=0, s-maxage=0, must-revalidate" always;


### PR DESCRIPTION
This reverts commit 15117a2de9382ae2dcfb4d9c2e6fbf01de067a4e.

Without this change, there are some weird redirect issues when deploying EDA using the operator right now.

If I navigate to:
* https://eda-host/, or 
* https://eda-host/eda, I get page not found, with a 200 (not 404).  However, if I click "Return to Dashboard", it will bring me to the login page, and I can log in and see the dashboard.

![image](https://github.com/ansible/eda-server-operator/assets/11698892/46f66595-acaa-4e48-b957-3489b150fa22)
