### PR TITLE
fix: enable BUILD_ARGS in docker-buildx target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
+	- docker buildx build --push $(BUILD_ARGS) --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
 	- docker buildx rm project-v3-builder
 
 ##@ Deployment


### PR DESCRIPTION
Tested locally (not in CI) only:

```bash
$ PLATFORMS=linux/amd64 \
> BUILD_ARGS="--build-arg DEFAULT_EDA_VERSION=sha-85c4398 \
>             --build-arg DEFAULT_EDA_UI_VERSION=2.4.872 \
>             --build-arg OPERATOR_VERSION=1.0.0" \
> IMG=registry.example.com/ansible/eda-server-operator:1.0.0 \
> make docker-buildx
docker buildx create --name project-v3-builder
project-v3-builder
docker buildx use project-v3-builder
docker buildx build --push --build-arg DEFAULT_EDA_VERSION=sha-85c4398             --build-arg DEFAULT_EDA_UI_VERSION=2.4.872             --build-arg OPERATOR_VERSION=1.0.0 --platform=linux/amd64 --tag registry.example.com/ansible/eda-server-operator:1.0.0 -f Dockerfile .
[+] Building 36.9s (13/13) FINISHED                                                                         
 => [internal] booting buildkit                                                                        2.5s
 => => pulling image moby/buildkit:buildx-stable-1                                                     1.9s
 => => creating container buildx_buildkit_project-v3-builder0                                          0.6s
 => [internal] load build definition from Dockerfile                                                   0.0s
 => => transferring dockerfile: 775B                                                                   0.0s
 => [internal] load metadata for quay.io/operator-framework/ansible-operator:v1.27.0                   3.1s
 => [internal] load .dockerignore                                                                      0.0s
 => => transferring context: 230B                                                                      0.0s
 => [1/6] FROM quay.io/operator-framework/ansible-operator:v1.27.0@sha256:7d6cc680ab0f57f2e796411c17  17.6s
 => => resolve quay.io/operator-framework/ansible-operator:v1.27.0@sha256:7d6cc680ab0f57f2e796411c170  0.0s
 => => sha256:a410cb638594e3774ca48c587754784c212d329f81b52a4a26ce2203a2b02d40 25.02MB / 25.02MB       2.1s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B               0.9s
 => => sha256:a162900bde72611bfe03489fa69f56edaad3c94aaca3e6e9c15ae1b75bddb995 581B / 581B             0.9s
 => => sha256:86f5f62afd6ec97574bc09469a6604f44273cfb2af7b9c5ce879f1003e90791b 9.47kB / 9.47kB         0.9s
 => => sha256:d19cab6e4eba8015a6d4ddff46c82c61c08bed40c058748e347463f4cfc58f27 64.88MB / 64.88MB       7.2s
 => => sha256:e480d2ae103c3e5cdcd0b1159aa570815696ae5976448bb74b4bf50201e89d75 13.94kB / 13.94kB       1.0s
 => => sha256:af3f0c395f7eb1853f50487d3c93853f4247e671c33362b4da71a23b351d5c54 262B / 262B             0.3s
 => => sha256:649e5534d134eac0f942db1db2a7491173c90e40888923ebf261d0277c2ab73e 79.14MB / 79.14MB      11.3s
 => => extracting sha256:649e5534d134eac0f942db1db2a7491173c90e40888923ebf261d0277c2ab73e              1.7s
 => => extracting sha256:af3f0c395f7eb1853f50487d3c93853f4247e671c33362b4da71a23b351d5c54              0.0s
 => => extracting sha256:e480d2ae103c3e5cdcd0b1159aa570815696ae5976448bb74b4bf50201e89d75              0.0s
 => => extracting sha256:d19cab6e4eba8015a6d4ddff46c82c61c08bed40c058748e347463f4cfc58f27              2.9s
 => => extracting sha256:86f5f62afd6ec97574bc09469a6604f44273cfb2af7b9c5ce879f1003e90791b              0.0s
 => => extracting sha256:a162900bde72611bfe03489fa69f56edaad3c94aaca3e6e9c15ae1b75bddb995              0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1              0.0s
 => => extracting sha256:a410cb638594e3774ca48c587754784c212d329f81b52a4a26ce2203a2b02d40              0.4s
 => [internal] load build context                                                                      0.0s
 => => transferring context: 147.34kB                                                                  0.0s
 => [2/6] COPY requirements.yml /opt/ansible/requirements.yml                                          0.5s
 => [3/6] RUN ansible-galaxy collection install -r /opt/ansible/requirements.yml  && chmod -R ug+rwx  12.8s
 => [4/6] COPY watches.yaml /opt/ansible/watches.yaml                                                  0.0s
 => [5/6] COPY roles/ /opt/ansible/roles/                                                              0.0s
 => [6/6] COPY playbooks/ /opt/ansible/playbooks/                                                      0.0s 
 => exporting to image                                                                                 0.2s 
 => => exporting layers                                                                                0.1s 
 => => exporting manifest sha256:3a91612e86cdf2b1501cf6bf05203e0fcae7dbe3dc62a1c2b7b55680c0be6c0d      0.0s 
 => => exporting config sha256:8d7aa7ccf185e9a5b0f725abf4680d4b198def582e3b73d2f8c4981b692fdbe7        0.0s
 => => pushing layers                                                                                  0.1s
 => => pushing manifest for registry.example.com/ansible/eda-server-operator:1.0.0@sha256:3a91612e86c  0.0s
 => [auth] sharing credentials for registry.example.com                                                0.0s
docker buildx rm project-v3-builder

$ docker run --rm -it --entrypoint bash registry.example.com/ansible/eda-server-operator:1.0.0 -c env | sort | grep VERSION
DEFAULT_EDA_UI_VERSION=2.4.872
DEFAULT_EDA_VERSION=sha-85c4398
OPERATOR_VERSION=1.0.0
TINI_VERSION=v0.19.0
```