### PR TITLE
Adding POSTGRES_ variables to support postgres official images

### DIFF
--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -69,6 +69,7 @@ spec:
             initialDelaySeconds: 45
             timeoutSeconds: 2
           env:
+            # For postgres_image based on rhel8/postgresql-13
             - name: POSTGRESQL_DATABASE
               valueFrom:
                 secretKeyRef:
@@ -80,6 +81,22 @@ spec:
                   name: '{{ __database_secret }}'
                   key: username
             - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ __database_secret }}'
+                  key: password
+            # For postgres_image based on postgres
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ __database_secret }}'
+                  key: database
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ __database_secret }}'
+                  key: username
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: '{{ __database_secret }}'


### PR DESCRIPTION
Makes EDA compatible with postgres official images. Block of code taken from awx operator, but modifed for this project.

Reference: https://github.com/ansible/awx-operator/blob/devel/roles/installer/templates/statefulsets/postgres.yaml.j2

Closes #175