### PR TITLE
Change apiVersion field for redis deployment to app/v1

### DIFF
--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ ansible_operator_meta.name }}-redis"


### PR DESCRIPTION
Fixes #174 

This PR updates the apiVersion field for the redis deployment from `v1` to `apps/v1` to directly find the deployment via apps group. This makes the template consistent with the other deployments created by the operator.