### PR TITLE
Fix Force DB Drop command

### DIFF
--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -80,25 +80,34 @@
       -p {{ eda_postgres_port }}
   no_log: "{{ no_log }}"
 
-- name: Set drop db command
-  set_fact:
-    pg_drop_db: >-
-      echo 'DROP DATABASE {{ eda_postgres_database }} WITH (FORCE);' | PGPASSWORD='{{ eda_postgres_pass }}' psql
-      -U {{ eda_postgres_user }}
-      -h {{ resolvable_db_host }}
-      -d postgres
-      -p {{ eda_postgres_port }}
-  no_log: "{{ no_log }}"
+- name: Force drop and create database if force_drop_db is true
+  block:
+    - name: Set drop db command
+      set_fact:
+        pg_drop_db: >-
+          echo 'DROP DATABASE {{ eda_postgres_database }} WITH (FORCE);' | PGPASSWORD='{{ eda_postgres_pass }}' psql
+          -U {{ eda_postgres_user }}
+          -h {{ resolvable_db_host }}
+          -d postgres
+          -p {{ eda_postgres_port }}
+      no_log: "{{ no_log }}"
 
-- name: Set create db command
-  set_fact:
-    pg_create_db: >-
-      echo 'CREATE DATABASE {{ eda_postgres_database }} WITH OWNER = {{ eda_postgres_user }};' | PGPASSWORD='{{ eda_postgres_pass }}' psql
-      -U {{ eda_postgres_user }}
-      -h {{ resolvable_db_host }}
-      -d postgres
-      -p {{ eda_postgres_port }}
-  no_log: "{{ no_log }}"
+    - name: Set create db command
+      set_fact:
+        pg_create_db: >-
+          echo 'CREATE DATABASE {{ eda_postgres_database }} WITH OWNER = {{ eda_postgres_user }};' | PGPASSWORD='{{ eda_postgres_pass }}' psql
+          -U {{ eda_postgres_user }}
+          -h {{ resolvable_db_host }}
+          -d postgres
+          -p {{ eda_postgres_port }}
+      no_log: "{{ no_log }}"
+
+    - name: Set complete pg restore command
+      set_fact:
+        pg_drop_create: >-
+          {{ pg_drop_db }}
+          {{ pg_create_db }}
+  when: force_drop_db
 
 - name: Restore database dump to the new postgresql container
   k8s_exec:
@@ -122,13 +131,11 @@
       trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
       echo keepalive_pid: $keepalive_pid
       set -e -o pipefail
-      if {{ force_drop_db }}; then
-        {{ pg_drop_db }}
-        {{ pg_create_db }}
-      fi
+      {{ pg_drop_create }}
       cat {{ backup_dir }}/eda.db | PGPASSWORD='{{ eda_postgres_pass }}' {{ pg_restore }}
-      echo 'Successful'
+      PG_RC=$?
+      set +e +o pipefail
+      exit $PG_RC
       "
   register: data_migration
   no_log: "{{ no_log }}"
-  failed_when: "'Successful' not in data_migration.stdout"

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -7,3 +7,6 @@ _postgres_image_version: latest
 
 backup_api_version: '{{ deployment_type }}.ansible.com/v1alpha1'
 backup_kind: 'EDABackup'
+
+force_drop_db: false
+pg_drop_create: ''


### PR DESCRIPTION
Currently, when running the restore role, we see this error:

```
 TASK [Restore database dump to the new postgresql container] ******************************** 
[0;31mfatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'force_drop_db' is undefined\n\nThe error appears to be in '/opt/ansible/roles/restore/tasks/postgres.yml': line 103, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Restore database dump to the new postgresql container\n  ^ here\n"}[0m
```

This is because no default was set in eda/defaults/vars.yml.

This PR resolves that and a few other things to better align with the awx-operator.  