### PR TITLE
Document the correct var name for EDA_MAX_RUNNING_ACTIVATIONS

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2450,6 +2450,7 @@ spec:
                     setting:
                       type: string
                     value:
+                      type: string
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -234,11 +234,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: API Extra Settings
+      - displayName: Extra Settings
         path: extra_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: PostgreSQL Database configuration
         path: database
         x-descriptors:

--- a/docs/user-guide/advanced-configuration/settings.md
+++ b/docs/user-guide/advanced-configuration/settings.md
@@ -12,7 +12,7 @@ metadata:
 spec:
   ...
   extra_settings:
-    - setting: MAX_RUNNING_ACTIVATIONS
+    - setting: EDA_MAX_RUNNING_ACTIVATIONS
       value: "12"
 
 ```
@@ -25,4 +25,4 @@ Below is a table of the setting name, default value, and a description of it's p
 
 | Setting Name             | Default Value  | Description                                     |
 |--------------------------|----------------|-------------------------------------------------|
-| MAX_RUNNING_ACTIVATIONS  | "12"           | Maximum number of running activations           |
+| EDA_MAX_RUNNING_ACTIVATIONS  | "12"           | Maximum number of running activations           |


### PR DESCRIPTION
Update docs example to reflect to correct var name for `EDA_MAX_RUNNING_ACTIVATIONS`

Also, with this change, we can now configure extra_settings from the Openshift/OKD UI.

Related PR: https://github.com/ansible/awx-operator/pull/1732

![image](https://github.com/ansible/eda-server-operator/assets/11698892/08fd8697-f43e-4d94-8876-2c06115b3db0)


![image](https://github.com/ansible/eda-server-operator/assets/11698892/670c25de-3db2-4297-a6b0-12697b1b1bbf)
