### PR TITLE
Rename initContainer to run migrations for consistency

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -65,7 +65,7 @@ spec:
         {{ combined_api.topology_spread_constraints | indent(width=8) }}
 {% endif %}
       initContainers:
-      - name: eda-migrations
+      - name: run-migrations
         image: {{ _image }}
         imagePullPolicy: '{{ image_pull_policy }}'
         command: ['aap-eda-manage', 'migrate']


### PR DESCRIPTION
The initContainer for running migrations is now renamed to `run-migrations` like the rest of the operators.  