### PR TITLE
Revert change to cast settings values to strings as they could be nested

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2450,7 +2450,6 @@ spec:
                     setting:
                       type: string
                     value:
-                      type: string
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -238,6 +238,7 @@ spec:
         path: extra_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: PostgreSQL Database configuration
         path: database
         x-descriptors:


### PR DESCRIPTION
Similar to https://github.com/ansible/awx-operator/pull/1756

There are issues when casting extra_settings values to string because not all settings values are strings, some are lists.