### PR TITLE
    Use docker engine for container build make targets in release GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Promote Operator Release
 
+env:
+  ENGINE: docker # use docker for everything so buildx commands can be used
+
 on:
   release:
     types: [published]
@@ -66,7 +69,7 @@ jobs:
 
       - name: Build Bundle Image
         run: |
-          make bundle bundle-build IMG=eda-server-operator:${TAG_NAME} VERSION=${TAG_NAME} BUNDLE_IMG=eda-server-operator-bundle:${TAG_NAME}
+          make bundle bundle-build IMG=quay.io/ansible/eda-server-operator:${TAG_NAME} VERSION=${TAG_NAME} BUNDLE_IMG=eda-server-operator-bundle:${TAG_NAME}
           docker tag eda-server-operator-bundle:${TAG_NAME} eda-server-operator-bundle:latest
         working-directory: eda-server-operator
 


### PR DESCRIPTION
    - engine defaults to podman, but podman does not support all docker
      buildx features at the moment
    - for now, we can solve this by using docker everywhere in this workflow
    - fix galaxy-operator image refs in CSV

I have re-pushed 1.0.0 and 1.0.1 with these changes and confirmed that the full image is now present in the resulting CSV in the bundles.

Before:
```
$ opm alpha bundle unpack quay.io/ansible/eda-server-operator-bundle:1.0.1
$ cat manifests/eda-server-operator.clusterserviceversion.yaml | grep image: | grep eda-server-operator:1.0.1
                image: eda-server-operator:1.0.1
```

After:

```
$ opm alpha bundle unpack quay.io/ansible/eda-server-operator-bundle:1.0.1
$ cat manifests/eda-server-operator.clusterserviceversion.yaml | grep image: | grep eda-server-operator:1.0.1
                image: quay.io/ansible/eda-server-operator:1.0.1

```