### PR TITLE
add postgres_security_context_settings

### DIFF
--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -31,6 +31,9 @@ spec:
         app.kubernetes.io/managed-by: 'eda-operator' 
     spec:
       securityContext:
+{% if postgres_security_context_settings|length %}
+        {{ postgres_security_context_settings | to_nice_yaml | indent(8) }}
+{% endif %}
         allowPrivilegeEscalation: false
         capabilities:
           drop: ["ALL"]


### PR DESCRIPTION
Adding the option to add custom security context for Postgres as in K8s it does not start due to a permission issue. This allows to change the user id, group id, etc to anything other than 26 used by the image https://quay.io/repository/sclorg/postgresql-13-c9s

https://github.com/ansible/eda-server-operator/issues/138

Example usage:
```
postgres_security_context_settings:
    runAsUser: 1001
    fsGroup: 1001
```