### PR TITLE
Pin Redis image tag to c9s because latest is no more

### DIFF
--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version.md
@@ -11,7 +11,7 @@ There are a few variables that are customizable for eda the image management.
 | image_pull_policy      | The pull policy to adopt  | IfNotPresent                            |
 | image_pull_secrets     | The pull secrets to use   | None                                    |
 | redis_image            | Path of the image to pull | redis                                   |
-| redis_image_version    | Image version to pull     | latest                                  |
+| redis_image_version    | Image version to pull     | c9s                                     |
 | postgres_image         | Path of the image to pull | postgres                                |
 | postgres_image_version | Image version to pull     | latest                                  |
 

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -7,7 +7,7 @@ image_pull_policy: IfNotPresent
 image_pull_secrets: []
 
 _redis_image: quay.io/sclorg/redis-6-c9s
-_redis_image_version: latest
+_redis_image_version: c9s
 
 redis: {}
 _redis:


### PR DESCRIPTION
Pin Redis image tag to c9s because latest is no more

Without this change, we get:

```
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  2m38s                default-scheduler  Successfully assigned eda/eda-redis-99c7f6c8f-lh9qh to awx.example.com
  Normal   Pulling    73s (x4 over 2m38s)  kubelet            Pulling image "quay.io/sclorg/redis-6-c9s:latest"
  Warning  Failed     73s (x4 over 2m38s)  kubelet            Failed to pull image "quay.io/sclorg/redis-6-c9s:latest": rpc error: code = NotFound desc = failed to pull and unpack image "quay.io/sclorg/redis-6-c9s:latest": failed to resolve reference "quay.io/sclorg/redis-6-c9s:latest": quay.io/sclorg/redis-6-c9s:latest: not found
  Warning  Failed     73s (x4 over 2m38s)  kubelet            Error: ErrImagePull
  Warning  Failed     49s (x6 over 2m37s)  kubelet            Error: ImagePullBackOff
  Normal   BackOff    36s (x7 over 2m37s)  kubelet            Back-off pulling image "quay.io/sclorg/redis-6-c9s:latest"
```