### PR TITLE
fix: redure replicas for the activation workers and increase replicas for the scheduler

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -1745,7 +1745,7 @@ spec:
                 type: object
               scheduler:
                 default:
-                  replicas: 1
+                  replicas: 2
                 description: Defines desired state of eda-scheduler resources
                 properties:
                   node_selector:
@@ -1754,9 +1754,9 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 1
+                    default: 2
                     description: 'Size is the size of number of eda-scheduler replicas.
-                      Default: 1'
+                      Default: 2'
                     format: int32
                     minimum: 0
                     nullable: true

--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -764,7 +764,7 @@ spec:
                   replicas:
                     default: 2
                     description: 'Size is the size of number of eda-default-worker replicas.
-                      Default: 1'
+                      Default: 2'
                     format: int32
                     minimum: 0
                     nullable: true
@@ -1092,9 +1092,9 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 5
+                    default: 2
                     description: 'Size is the size of number of eda-activation-worker replicas.
-                      Default: 5'
+                      Default: 2'
                     format: int32
                     minimum: 0
                     nullable: true
@@ -1424,7 +1424,7 @@ spec:
                   replicas:
                     default: 2
                     description: 'Size is the size of number of eda-worker replicas.
-                      Default: 1'
+                      Default: 2'
                     format: int32
                     minimum: 0
                     nullable: true

--- a/config/samples/eda_v1alpha1_eda.yaml
+++ b/config/samples/eda_v1alpha1_eda.yaml
@@ -26,7 +26,7 @@ spec:
         cpu: 150m
         memory: 256Mi
   activation_worker:
-    replicas: 3
+    replicas: 2
     resource_requirements:
       requests:
         cpu: 150m

--- a/config/samples/eda_v1alpha1_eda.yaml
+++ b/config/samples/eda_v1alpha1_eda.yaml
@@ -31,6 +31,12 @@ spec:
       requests:
         cpu: 150m
         memory: 256Mi
+  scheduler:
+    replicas: 2
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
   ui:
     replicas: 1
     resource_requirements:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -111,7 +111,7 @@ Create a playbook that invokes the installer role (the operator uses ansible-run
           cpu: 200m
           memory: 512Mi
     activation_worker:
-      replicas: 3
+      replicas: 2
       resource_requirements:
         requests:
           cpu: 200m

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -70,7 +70,7 @@ _worker:
 
 scheduler: {}
 _scheduler:
-  replicas: 1
+  replicas: 2
   resource_requirements:
     requests:
       cpu: 50m

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -50,7 +50,7 @@ _default_worker:
 
 # Note: "activation-worker: {}" is intentionally excluded here so we know if the user set it
 _activation_worker:
-  replicas: 5
+  replicas: 2
   resource_requirements:
     requests:
       cpu: 25m


### PR DESCRIPTION
Closes #194 

**Changes:**

- Reduce default replicas for Acrivation Worker (from 5 to 2)
- Reduce replicas for Activation Worker in samples and docs
- Fix incorrect default values in the `description` for `replicas` for Default Worker (from 1 to 2)
- Increase default replicas for Scheduler (from 1 to 2) 
- Add `scheduler` to the sample CR

**Test:**

Deploy minimal CR without specifying any replicas:

```yaml
---
apiVersion: eda.ansible.com/v1alpha1
kind: EDA
metadata:
  namespace: eda
  name: eda
spec:
  automation_server_url: https://awx.example.com
  service_type: NodePort
  nodeport_port: 30280
```

I can confirm that default replicas is 2 for both Default Worker and Activation Worker:

```bash
$ kubectl -n eda get deployment,pod
NAME                                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/eda-server-operator-controller-manager   1/1     1            1           7m22s
deployment.apps/eda-redis                                1/1     1            1           4m42s
deployment.apps/eda-ui                                   1/1     1            1           3m41s
deployment.apps/eda-default-worker                       2/2     2            2           3m38s     ✅
deployment.apps/eda-activation-worker                    2/2     2            2           3m36s     ✅
deployment.apps/eda-scheduler                            2/2     2            2           3m34s     ✅
deployment.apps/eda-api                                  1/1     1            1           3m44s

NAME                                                         READY   STATUS    RESTARTS   AGE
pod/eda-server-operator-controller-manager-654699f4c-w4hhl   2/2     Running   0          6m4s
pod/eda-redis-747596546f-bmd5x                               1/1     Running   0          4m42s
pod/eda-postgres-15-0                                        1/1     Running   0          4m29s
pod/eda-ui-54c6bcd6df-9ksdn                                  1/1     Running   0          3m41s
pod/eda-default-worker-5b8c5bbf7b-w8747                      1/1     Running   0          3m38s     ✅
pod/eda-default-worker-5b8c5bbf7b-854gn                      1/1     Running   0          3m38s     ✅
pod/eda-activation-worker-575c746969-rfcv9                   1/1     Running   0          3m36s     ✅
pod/eda-activation-worker-575c746969-jdfdx                   1/1     Running   0          3m36s     ✅
pod/eda-scheduler-7bf4cf688f-z5dmk                           1/1     Running   0          3m34s     ✅
pod/eda-scheduler-7bf4cf688f-9nf2w                           1/1     Running   0          3m34s     ✅
pod/eda-api-6b9477d684-67zm9                                 2/2     Running   0          3m44s
```