### PR TITLE
fix: make undeploy to respect user-provided namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/c
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
+	cd config/default && $(KUSTOMIZE) edit set namespace ${NAMESPACE}
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
**Changes:**

- Allow users to specify non-default `NAMESPACE` for `make undeploy`

**Original issue:**

The command `NAMESPACE=eda make undeploy` does not works as expected after `git checkout .`.

```bash
# Deploy Operator on `eda` namespace
$ NAMESPACE=eda make deploy
cd config/manager && /home/kuro/work/kurokobo/eda-server-operator/bin/kustomize edit set image controller=quay.io/ansible/eda-server-operator:0.0.1
cd config/default && /home/kuro/work/kurokobo/eda-server-operator/bin/kustomize edit set namespace eda
/home/kuro/work/kurokobo/eda-server-operator/bin/kustomize build config/default | kubectl apply -f -
namespace/eda created
...

# Revert local changes
$ git checkout .
Updated 2 paths from the index

# Try to undeploy everything on `eda` namespace, but `NAMESPACE=eda` is ignored
$ NAMESPACE=eda make undeploy
/home/kuro/work/kurokobo/eda-server-operator/bin/kustomize build config/default | kubectl delete -f -
customresourcedefinition.apiextensions.k8s.io "edabackups.eda.ansible.com" deleted
customresourcedefinition.apiextensions.k8s.io "edarestores.eda.ansible.com" deleted
customresourcedefinition.apiextensions.k8s.io "edas.eda.ansible.com" deleted
clusterrole.rbac.authorization.k8s.io "eda-server-operator-metrics-reader" deleted
clusterrole.rbac.authorization.k8s.io "eda-server-operator-proxy-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "eda-server-operator-proxy-rolebinding" deleted
Error from server (NotFound): error when deleting "STDIN": namespaces "eda-server-operator-system" not found     ✅
...
make: *** [Makefile:122: undeploy] Error 1
```

**Test:**

```bash
$ NAMESPACE=eda make deploy
cd config/manager && /home/kuro/work/kurokobo/eda-server-operator/bin/kustomize edit set image controller=quay.io/ansible/eda-server-operator:0.0.1
cd config/default && /home/kuro/work/kurokobo/eda-server-operator/bin/kustomize edit set namespace eda
/home/kuro/work/kurokobo/eda-server-operator/bin/kustomize build config/default | kubectl apply -f -
namespace/eda created
...

$ git checkout .
Updated 2 paths from the index

$ NAMESPACE=eda make undeploy
cd config/default && /home/kuro/work/kurokobo/eda-server-operator/bin/kustomize edit set namespace eda
/home/kuro/work/kurokobo/eda-server-operator/bin/kustomize build config/default | kubectl delete -f -
namespace "eda" deleted     ✅
...
```