### PR TITLE
eda: Add WEBSOCKET_TOKEN_BASE_URL to settings

### DIFF
--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -20,6 +20,7 @@ data:
   EDA_CSRF_TRUSTED_ORIGINS: "http://{{ ansible_operator_meta.name }}-api:8000"
   EDA_MQ_HOST: "{{ ansible_operator_meta.name }}-redis-svc"
   EDA_WEBSOCKET_BASE_URL: "ws://{{ websocket_server_name }}:8001"
+  EDA_WEBSOCKET_TOKEN_BASE_URL: "http://{{ ansible_operator_meta.name }}-api:8000"
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"
   EDA_PROTOCOL: "http"
   EDA_HOST: "{{ ansible_operator_meta.name }}-api:8000"


### PR DESCRIPTION
The activation workers need to access to the api (gunicorn) for refreshing the token.

This is done via the `WEBSOCKET_BASE_URL` value but both gunicorn and daphne need to be available via this url.

However for k8s deployment `WEBSOCKET_BASE_URL` points directly to the daphne service rather than going back to nginx.

https://github.com/ansible/eda-server/commit/3353129