### PR TITLE
Ensure deprecated worker var is not preferred over activation and defaults

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -89,7 +89,6 @@ spec:
                 description: Defines desired state of eda-api resources
                 properties:
                   gunicorn_workers:
-                    default: 2
                     description: 'The number of gunicorn workers for the api.
                       Default: 2'
                     format: int32
@@ -102,7 +101,6 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 1
                     description: 'Size is the size of number of eda-api replicas.
                       Default: 1'
                     format: int32
@@ -432,7 +430,6 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 1
                     description: 'Size is the size of number of eda-ui replicas.
                       Default: 1'
                     format: int32
@@ -762,7 +759,6 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 2
                     description: 'Size is the size of number of eda-default-worker replicas.
                       Default: 2'
                     format: int32
@@ -1092,7 +1088,6 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 2
                     description: 'Size is the size of number of eda-activation-worker replicas.
                       Default: 2'
                     format: int32
@@ -1422,7 +1417,6 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 2
                     description: 'Size is the size of number of eda-worker replicas.
                       Default: 2'
                     format: int32
@@ -1744,8 +1738,6 @@ spec:
                     type: array
                 type: object
               scheduler:
-                default:
-                  replicas: 2
                 description: Defines desired state of eda-scheduler resources
                 properties:
                   node_selector:
@@ -1754,7 +1746,6 @@ spec:
                     description: NodeSelector for the EDA pods.
                     type: object
                   replicas:
-                    default: 2
                     description: 'Size is the size of number of eda-scheduler replicas.
                       Default: 2'
                     format: int32
@@ -2079,7 +2070,6 @@ spec:
                 description: 'Defines desired state of cache resources'
                 properties:
                   replicas:
-                    default: 1
                     description: 'Defines Redis Deployment replicas'
                     format: int32
                     type: integer
@@ -2311,7 +2301,6 @@ spec:
                   postgres_keep_pvc_after_upgrade:
                     description: Specify whether or not to keep the old PVC after PostgreSQL upgrades
                     type: boolean
-                    default: true
                   storage_requirements:
                     description: Storage requirements for the PostgreSQL container
                     properties:
@@ -2380,7 +2369,6 @@ spec:
               set_self_labels:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean
-                default: true
               service_type:
                 description: The service type to be used on the deployed instance
                 type: string
@@ -2421,21 +2409,18 @@ spec:
               loadbalancer_protocol:
                 description: Protocol to use for the loadbalancer
                 type: string
-                default: http
                 enum:
                 - http
                 - https
               loadbalancer_port:
                 description: Port to use for the loadbalancer
                 type: integer
-                default: 80
               route_host:
                 description: The DNS to use to points to the instance
                 type: string
               route_tls_termination_mechanism:
                 description: The secure TLS termination mechanism to use
                 type: string
-                default: Edge
                 enum:
                 - Edge
                 - edge
@@ -2476,14 +2461,12 @@ spec:
               ipv6_disabled:
                 description: Disable UI container's nginx ipv6 listener
                 type: boolean
-                default: false
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string
               force_drop_db:
                 description: Force drop the database before restoring. USE WITH CAUTION!
                 type: boolean
-                default: false
           status:
             description: Status defines the observed state of EDA
             properties:

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -201,11 +201,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: Disable IPv6 listener?
-        path: ipv6_disabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Name of the k8s secret the DB fields encryption key is stored
           in.
         displayName: DB Fields Encryption Key
@@ -405,6 +400,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Defines desired state of eda-default-worker deployment resources
+        displayName: (Deprecated) Default worker deployment configuration
+        path: worker
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Defines desired state of eda-default-worker deployment resources
         displayName: Default worker deployment configuration
         path: default_worker
         x-descriptors:
@@ -475,7 +475,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Defines desired state of eda-scheduler deployment resources
-        displayName: scheduler deployment configuration
+        displayName: Scheduler deployment configuration
         path: scheduler
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -634,6 +634,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:service_type:NodePort
       - description: Secret where the trusted Certificate Authority Bundle is stored
+        displayName: Bundle CA Cert Secret
         path: bundle_cacert_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -643,6 +644,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Disable IPv6 listener?
+        path: ipv6_disabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Set default labels on EDA resource
         path: set_self_labels
         x-descriptors:
@@ -652,7 +658,7 @@ spec:
       - displayName: Force drop database before restore
         path: force_drop_db
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
       - description: Admin password for the instance deployed

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -59,14 +59,7 @@ _activation_worker:
   tolerations: ''
 
 # Note: Deprecated "worker: {}" is intentionally excluded here so we know if the user set it
-_worker:
-  replicas: 2
-  resource_requirements:
-    requests:
-      cpu: 25m
-      memory: 130Mi
-  node_selector: ''
-  tolerations: ''
+_worker: {}
 
 scheduler: {}
 _scheduler:

--- a/roles/eda/tasks/combine_defaults.yml
+++ b/roles/eda/tasks/combine_defaults.yml
@@ -22,12 +22,10 @@
   set_fact:
     combined_default_worker: "{{ _default_worker | combine(default_worker, recursive=True) }}"
   when:
-    - worker is not defined
     - default_worker is defined
 
 - name: Set activation worker parameters when worker is not defined
   set_fact:
     combined_activation_worker: "{{ _activation_worker | combine(activation_worker, recursive=True) }}"
   when:
-    - worker is not defined
     - activation_worker is defined


### PR DESCRIPTION
There was a bug that was affecting the precedence order.  Now the correct precedence order will be enforced:

* `default_worker` > `worker` > `_default_worker`

While here, I cleaned up the CSV more to hide confusing values from users in the yaml form in the UI. 
- Clean up the defaults in the CSV and use the defaults/main.yml values
- This cleans up the auto-populated yaml in the UI form, hiding obscure and deprecated params