### PR TITLE
Add support for spec overrides when restoring EDA

### DIFF
--- a/config/crd/bases/eda.ansible.com_edarestores.yaml
+++ b/config/crd/bases/eda.ansible.com_edarestores.yaml
@@ -93,6 +93,10 @@ spec:
               postgres_image_version:
                 description: PostgreSQL container image version to use
                 type: string
+              spec_overrides:
+                description: Overrides for the EDA spec
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               no_log:
                 description: Configure no_log for no_log tasks
                 type: boolean

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -148,6 +148,10 @@ spec:
         path: postgres_image_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: EDA Spec Overrides
+        path: spec_overrides
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Restore Management Pod Resource Requirements
         path: restore_resource_requirements
         x-descriptors:

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -28,4 +28,6 @@ restore_resource_requirements:
 
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
+
+spec_overrides: {}
 ...

--- a/roles/restore/tasks/deploy_eda.yml
+++ b/roles/restore/tasks/deploy_eda.yml
@@ -1,4 +1,8 @@
 ---
+- name: Combine spec_overrides with spec
+  set_fact:
+    spec: "{{ spec | default({}) | combine(spec_overrides) }}"
+  no_log: "{{ no_log }}"
 
 - name: Deploy EDA
   k8s:


### PR DESCRIPTION
Port of restore overrides PR from the awx-operator:
* https://github.com/ansible/awx-operator/pull/1862

##### SUMMARY

There are often times where you might want to override specific parameters on the Galaxy spec when restoring from a backup. One such case is when you want to extend the database PVC size.  

To extend the storage size of your postgres PVC, with this change, you can now:
1. Create an GalaxyBackup
2. Create an GalaxyRestore with a spec_overrides entry for `spec_overrides.postgres_storage_requirements.requests: 110Gi` on your GalaxyRestore object
3. The new deployment will have any spec_overrides preferentially included on the new Galaxy CR spec.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
