### PR TITLE
fix defaults for node_selector and tolerations

### DIFF
--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -36,7 +36,7 @@ _api:
       cpu: 50m
       memory: 350Mi
   node_selector: {}
-  node_selector: []
+  tolerations: []
 
 # Note: "default-worker: {}" is intentionally excluded here so we know if the user set it
 _default_worker:
@@ -46,7 +46,7 @@ _default_worker:
       cpu: 25m
       memory: 130Mi
   node_selector: {}
-  node_selector: []
+  tolerations: []
 
 # Note: "activation-worker: {}" is intentionally excluded here so we know if the user set it
 _activation_worker:
@@ -56,7 +56,7 @@ _activation_worker:
       cpu: 25m
       memory: 150Mi
   node_selector: {}
-  node_selector: []
+  tolerations: []
 
 # Note: Deprecated "worker: {}" is intentionally excluded here so we know if the user set it
 _worker: {}
@@ -69,7 +69,7 @@ _scheduler:
       cpu: 50m
       memory: 256Mi
   node_selector: {}
-  node_selector: []
+  tolerations: []
 
 ui: {}
 _ui:
@@ -79,7 +79,7 @@ _ui:
       cpu: 25m
       memory: 64Mi
   node_selector: {}
-  node_selector: []
+  tolerations: []
 
 # Labels defined on the resource, which should be propagated to child resources
 additional_labels: []

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -35,8 +35,8 @@ _api:
     requests:
       cpu: 50m
       memory: 350Mi
-  node_selector: ''
-  tolerations: ''
+  node_selector: {}
+  node_selector: []
 
 # Note: "default-worker: {}" is intentionally excluded here so we know if the user set it
 _default_worker:
@@ -45,8 +45,8 @@ _default_worker:
     requests:
       cpu: 25m
       memory: 130Mi
-  node_selector: ''
-  tolerations: ''
+  node_selector: {}
+  node_selector: []
 
 # Note: "activation-worker: {}" is intentionally excluded here so we know if the user set it
 _activation_worker:
@@ -55,8 +55,8 @@ _activation_worker:
     requests:
       cpu: 25m
       memory: 150Mi
-  node_selector: ''
-  tolerations: ''
+  node_selector: {}
+  node_selector: []
 
 # Note: Deprecated "worker: {}" is intentionally excluded here so we know if the user set it
 _worker: {}
@@ -68,8 +68,8 @@ _scheduler:
     requests:
       cpu: 50m
       memory: 256Mi
-  node_selector: ''
-  tolerations: ''
+  node_selector: {}
+  node_selector: []
 
 ui: {}
 _ui:
@@ -78,8 +78,8 @@ _ui:
     requests:
       cpu: 25m
       memory: 64Mi
-  node_selector: ''
-  tolerations: ''
+  node_selector: {}
+  node_selector: []
 
 # Labels defined on the resource, which should be propagated to child resources
 additional_labels: []

--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -54,11 +54,11 @@ spec:
 {% endif %}
 {% if combined_activation_worker.node_selector is defined %}
       nodeSelector:
-        {{ combined_activation_worker.node_selector | indent(width=8) }}
+        {{ combined_activation_worker.node_selector | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_activation_worker.tolerations is defined %}
       tolerations:
-        {{ combined_activation_worker.tolerations | indent(width=8) }}
+        {{ combined_activation_worker.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_activation_worker.topology_spread_constraints is defined %} %}
       topologySpreadConstraints:

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -54,11 +54,11 @@ spec:
 {% endif %}
 {% if combined_api.node_selector is defined %}
       nodeSelector:
-        {{ combined_api.node_selector | indent(width=8) }}
+        {{ combined_api.node_selector | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_api.tolerations is defined %}
       tolerations:
-        {{ combined_api.tolerations | indent(width=8) }}
+        {{ combined_api.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_api.topology_spread_constraints is defined %}
       topologySpreadConstraints:

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -54,11 +54,11 @@ spec:
 {% endif %}
 {% if combined_default_worker.node_selector is defined %}
       nodeSelector:
-        {{ combined_default_worker.node_selector | indent(width=8) }}
+        {{ combined_default_worker.node_selector | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_default_worker.tolerations is defined %}
       tolerations:
-        {{ combined_default_worker.tolerations | indent(width=8) }}
+        {{ combined_default_worker.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_default_worker.topology_spread_constraints is defined %} %}
       topologySpreadConstraints:

--- a/roles/eda/templates/eda-scheduler.deployment.yaml.j2
+++ b/roles/eda/templates/eda-scheduler.deployment.yaml.j2
@@ -53,11 +53,11 @@ spec:
 {% endif %}
 {% if combined_scheduler.node_selector is defined %}
       nodeSelector:
-        {{ combined_scheduler.node_selector | indent(width=8) }}
+        {{ combined_scheduler.node_selector | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_scheduler.tolerations is defined %}
       tolerations:
-        {{ combined_scheduler.tolerations | indent(width=8) }}
+        {{ combined_scheduler.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_scheduler.topology_spread_constraints is defined %} %}
       topologySpreadConstraints:

--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -53,11 +53,11 @@ spec:
 {% endif %}
 {% if combined_ui.node_selector is defined %}
       nodeSelector:
-        {{ combined_ui.node_selector | indent(width=8) }}
+        {{ combined_ui.node_selector | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_ui.tolerations is defined %}
       tolerations:
-        {{ combined_ui.tolerations | indent(width=8) }}
+        {{ combined_ui.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_ui.topology_spread_constraints is defined %} %}
       topologySpreadConstraints:

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -36,9 +36,9 @@ _database:
   storage_requirements:
     requests:
       storage: 8Gi
-  node_selector: ''
+  node_selector: {}
   priority_class: ''
-  tolerations: ''
+  tolerations: []
   postgres_extra_args: ''
   postgres_keep_pvc_after_upgrade: true  # Specify whether or not to keep the old PVC after PostgreSQL upgrades
   postgres_data_volume_init: false

--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -45,11 +45,11 @@ spec:
 {% endif %}
 {% if combined_database.node_selector %}
       nodeSelector:
-        {{ combined_database.node_selector | indent(width=8) }}
+        {{ combined_database.node_selector | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_database.tolerations %}
       tolerations:
-        {{ combined_database.tolerations | indent(width=8) }}
+        {{ combined_database.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_database.postgres_data_volume_init and not is_openshift %}
       initContainers:

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -16,8 +16,8 @@ _redis:
     requests:
       cpu: 50m
       memory: 100Mi
-  node_selector: ''
-  tolerations: ''
+  node_selector: {}
+  tolerations: []
 
 # Labels defined on the resource, which should be propagated to child resources
 additional_labels: []

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -36,11 +36,11 @@ spec:
 {% endif %}
 {% if combined_redis.node_selector %}
       nodeSelector:
-        {{ combined_redis.node_selector | indent(width=8) }}
+        {{ combined_redis.node_selector | to_nice_yaml | indent(width=8) }}
 {% endif %}
 {% if combined_redis.tolerations %}
       tolerations:
-        {{ combined_redis.tolerations | indent(width=8) }}
+        {{ combined_redis.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
       containers:
         - name: redis


### PR DESCRIPTION
When setting `node_selector` and `tolerations` values for all deployments/staefulsets, the playbook in the operator fails with the following error:
```
unsupported operand type(s) for +=: 'dict' and 'str'
```

The CRD defines the tolerations as [an array](https://github.com/ansible/eda-server-operator/blob/main/config/crd/bases/eda.ansible.com_edas.yaml#L208-L248), and the node_selector as [an object](https://github.com/ansible/eda-server-operator/blob/main/config/crd/bases/eda.ansible.com_edas.yaml#L98-L102).

The defaults for the roles are empty strings, so when trying to combine the `<component>` and `_<component>` dictionaries to render the final configuration,  a string is added to an array/dict and I get the aforementioned error.

It can be reproduced with this manifest using operator version 1.02:
```
apiVersion: eda.ansible.com/v1alpha1
kind: EDA
metadata:
  name: eda-demo
  namespace: eda
spec:
  no_log: false
  automation_server_url: http://awx-service.awx
  image: quay.io/ansible/eda-server
  image_version: main
  image_web: quay.io/ansible/eda-ui
  image_web_version: main
  ipv6_disabled: true
  ingress_type: ingress
  ingress_path: "/"
  ingress_path_type: Prefix
  hostname: my-eda.example.com
  api:
    node_selector:
      system/dedicated: my-node-group
    tolerations:
      - key: "system/dedicated"
        operator: "Equal"
        value: "my-node-group"
        effect: "NoSchedule"
  ui:
    node_selector:
      system/dedicated: my-node-group
    tolerations:
      - key: "system/dedicated"
        operator: "Equal"
        value: "my-node-group"
        effect: "NoSchedule"
  scheduler:
    node_selector:
      system/dedicated: my-node-group
    tolerations:
      - key: "system/dedicated"
        operator: "Equal"
        value: "my-node-group"
        effect: "NoSchedule"
  default_worker:
    node_selector:
      system/dedicated: my-node-group
    tolerations:
      - key: "system/dedicated"
        operator: "Equal"
        value: "my-node-group"
        effect: "NoSchedule"
  activation_worker:
    node_selector:
      system/dedicated: my-node-group
    tolerations:
      - key: "system/dedicated"
        operator: "Equal"
        value: "my-node-group"
        effect: "NoSchedule"
  redis:
    node_selector:
      system/dedicated: my-node-group
    tolerations:
      - key: "system/dedicated"
        operator: "Equal"
        value: "my-node-group"
        effect: "NoSchedule"
  database:
    node_selector:
      system/dedicated: my-node-group
    tolerations:
      - key: "system/dedicated"
        operator: "Equal"
        value: "my-node-group"
        effect: "NoSchedule"
 ```