### PR TITLE
Remove x-kubernetes-preserve-unknown-fields: true

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -32,7 +32,6 @@ spec:
           spec:
             description: Spec defines the desired state of EDA
             type: object
-            x-kubernetes-preserve-unknown-fields: true
             required:
             - automation_server_url
             properties:


### PR DESCRIPTION
Remove x-kubernetes-preserve-unknown-fields: true so that `oc explain eda.spec` works.

**Without this change:**

```
$ oc explain eda.spec
KIND:     EDA
VERSION:  eda.ansible.com/v1alpha1

DESCRIPTION:
     Spec defines the desired state of EDA

```


**With this change:**

```
$ oc explain eda.spec
KIND:     EDA
VERSION:  eda.ansible.com/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     Spec defines the desired state of EDA

FIELDS:
   activation_worker	<Object>
     Defines desired state of eda-activation-worker resources

   additional_labels	<[]string>
     Additional labels defined on the resource, which should be propagated to
     child resources

   admin_password_secret	<string>
     Secret where the admin password can be found. If not specified, one will be
     generated.

   admin_user	<string>
     Username to use for the admin account

   api	<Object>
     Defines desired state of eda-api resources

   automation_server_ssl_verify	<string>
     SSL Verify (yes, no) for the AWX automation host

   automation_server_url	<string> -required-
     URL of the AWX automation host to run ansible jobs against

   bundle_cacert_secret	<string>
     Secret where the trusted Certificate Authority Bundle is stored

   database	<Object>
     The EDA PostgreSQL database StatefulSet

   db_fields_encryption_secret	<string>
     Secret where the DB fields encryption key can be found. If not specified,
     one will be generated.

   default_worker	<Object>
     Defines desired state of eda-default-worker resources

   extra_settings	<[]Object>
     Environment variables to configure the application-level settings

   force_drop_db	<boolean>
     Force drop the database before restoring. USE WITH CAUTION!

   hostname	<string>
     The hostname of the instance

   image	<string>
     Registry path to API container image to use

   image_pull_policy	<string>
     The image pull policy

   image_pull_secrets	<[]string>
     Image pull secrets for app and database containers

   image_version	<string>
     API container image tag or version to use

   image_web	<string>
     Registry path to UI container image to use

   image_web_version	<string>
     UI container image tag or version to use

   ingress_annotations	<string>
     Annotations to add to the Ingress Controller

   ingress_api_version	<string>
     The Ingress API version to use

   ingress_class_name	<string>
     The name of ingress class to use instead of the cluster default.

   ingress_path	<string>
     The ingress path used to reach the deployed service

   ingress_path_type	<string>
     The ingress path type for the deployed service

   ingress_tls_secret	<string>
     Secret where the Ingress TLS secret can be found

   ingress_type	<string>
     The ingress type to use to reach the deployed instance

   ipv6_disabled	<boolean>
     Disable UI container's nginx ipv6 listener

   loadbalancer_port	<integer>
     Port to use for the loadbalancer

   loadbalancer_protocol	<string>
     Protocol to use for the loadbalancer

   no_log	<boolean>
     Configure no_log for no log tasks

   nodeport_port	<integer>
     Port to use for the nodeport

   postgres_image	<string>
     Registry path to the PostgreSQL container to use

   postgres_image_version	<string>
     PostgreSQL container image version to use

   redis	<Object>
     Defines desired state of cache resources

   redis_image	<string>
     Registry path to Redis container image to use

   redis_image_version	<string>
     Redis container image tag or version to use

   route_api_version	<string>
     The route API version to use

   route_host	<string>
     The DNS to use to points to the instance

   route_tls_secret	<string>
     Secret where the TLS related credentials are stored

   route_tls_termination_mechanism	<string>
     The secure TLS termination mechanism to use

   scheduler	<Object>
     Defines desired state of eda-scheduler resources

   service_account_annotations	<string>
     ServiceAccount annotations

   service_type	<string>
     The service type to be used on the deployed instance

   set_self_labels	<boolean>
     Maintain some of the recommended `app.kubernetes.io/*` labels on the
     resource (self)

   ui	<Object>
     Defines desired state of eda-ui resources

   worker	<Object>
     (Deprecated) Defines desired state of eda-worker resources
```