### PR TITLE
Ignore errors when creating Superuser, look for specific output instead

### DIFF
--- a/roles/eda/tasks/create_admin_user.yml
+++ b/roles/eda/tasks/create_admin_user.yml
@@ -23,5 +23,6 @@
   register: result
   changed_when: "'That username is already taken' not in result.stderr"
   failed_when: "'That username is already taken' not in result.stderr and 'Superuser created successfully' not in result.stdout"
+  ignore_errors: true
   no_log: "{{ no_log }}"
   when: users_result.return_code > 0


### PR DESCRIPTION
There is a temporary error that is hit when deploying EDA when this task runs and migrations have not yet been completed.  

```
 TASK [Create super user via Django if it doesn't exist.] ******************************** 
fatal: [localhost]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}
```

We should ignore errors to keep the logs clean. Subsequent reconciliation loops will handle the user creation.