### PR TITLE
Add ability to disable Redis

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2076,6 +2076,9 @@ spec:
               redis:
                 description: 'Defines desired state of cache resources'
                 properties:
+                  disabled:
+                    description: Disables default redis deployment if external redis is configured
+                    type: boolean
                   replicas:
                     description: 'Defines Redis Deployment replicas'
                     format: int32

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -518,6 +518,11 @@ spec:
         path: redis
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Disable the default redis deployment if an external Redis is configured
+        displayName: Disable Redis
+        path: redis.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The number of redis replicas.
         displayName: Replicas
         path: redis.replicas

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -18,7 +18,9 @@ data:
   # EDA Server
   EDA_ALLOWED_HOSTS: "['*']"
   EDA_CSRF_TRUSTED_ORIGINS: "http://{{ api_server_name }}:{{ api_port }}"
+  {%  if not eda.disabled %}
   EDA_MQ_HOST: "{{ ansible_operator_meta.name }}-redis-svc"
+  {% endif %}
   EDA_WEBSOCKET_BASE_URL: "ws://{{ websocket_server_name }}:{{ websocket_port }}"
   EDA_WEBSOCKET_TOKEN_BASE_URL: "http://{{ api_server_name }}:{{ api_port }}"
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -11,6 +11,7 @@ _redis_image_version: c9s
 
 redis: {}
 _redis:
+  disabled: false
   replicas: 1
   resource_requirements:
     requests:

--- a/roles/redis/tasks/create_redis.yml
+++ b/roles/redis/tasks/create_redis.yml
@@ -2,7 +2,7 @@
 
 - name: Redis Deployment & Service
   k8s:
-    state: present
+    state: "{{ 'absent' if _eda.redis.disabled else 'present' }}"
     apply: yes
     wait: no
     definition: "{{ lookup('template', 'templates/' + item + '.yaml.j2') | from_yaml }}"


### PR DESCRIPTION
This PR makes it possible to disable redis by setting `eda.spec.redis.disabled: true`.  This might be desired if configuring an external redis instance via the env settings.  

```
  extra_settings:
    - setting: EDA_MQ_USER
      value: '{{ eda_redis_username | b64decode }}'
    - setting: EDA_MQ_USER_PASSWORD
      value: '{{ eda_redis_password | b64decode }}'
    - setting: EDA_MQ_HOST
      value: '{{ eda_redis_host | b64decode }}'
    - setting: EDA_MQ_PORT
      value: '{{ eda_redis_port | b64decode }}'
```

**Alternative Idea:**

However, I think it might be better all around to make it so that the redis configuration is done via a k8s secret, and the presence of that k8s secret being specified on the EDA spec would indicate that an external Redis instance is being used configured and that the default redis pod/deployment/service should not be created.  

@rcarrillocruz What do you think about that idea?  If that's better, I can close this and implement it tomorrow.  