### PR TITLE
Do not deploy the UI and create a route for the api endpoints if UI is disabled

### DIFF
--- a/.ci/eda_v1alpha1_eda.default.ci.yaml
+++ b/.ci/eda_v1alpha1_eda.default.ci.yaml
@@ -7,3 +7,4 @@ metadata:
 spec:
   no_log: false
   automation_server_url: http://foo.bar
+  ui_disabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - SCENARIO: default
+          - SCENARIO: default  # tests headless scenario too
           - SCENARIO: externaldb
           - SCENARIO: ingress
     steps:
@@ -64,12 +64,23 @@ jobs:
           kubectl -n eda get eda eda-demo -o yaml
           kubectl wait --for condition=Successful --timeout=-1s -f .ci/eda_v1alpha1_eda.${{ matrix.SCENARIO }}.ci.yaml
 
-      - name: Test EDA API via k8s service
+      - name: Wait for the EDA API pod to be ready
+        run: |
+          kubectl wait --for condition=Ready --timeout=-1s -l app.kubernetes.io/component=eda-api
+
+      - name: Test EDA API via API k8s service
+        run: |
+          kubectl port-forward service/eda-demo-api 8081:8000 &
+          sleep 1
+          curl -s http://localhost:8081/api/eda/v1/status/
+        if: ${{ matrix.SCENARIO == 'default' }}
+
+      - name: Test EDA API via UI k8s service
         run: |
           kubectl port-forward service/eda-demo-ui 8080:80 &
           sleep 1
           curl -s http://localhost:8080/api/eda/v1/status/
-        if: ${{ matrix.SCENARIO != 'ingress' }}
+        if: ${{ matrix.SCENARIO != 'default' }}
 
       - name: Test EDA API via k8s ingress
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,12 +62,19 @@ jobs:
           kubectl -n eda get eda eda-demo -o yaml
           kubectl wait --for condition=Successful --timeout=-1s -f .ci/eda_v1alpha1_eda.${{ matrix.SCENARIO }}.ci.yaml
 
-      - name: Test EDA API via k8s service
+      - name: Test EDA API via API k8s service
+        run: |
+          kubectl port-forward service/eda-demo-api 8081:8000 &
+          sleep 1
+          curl -s http://localhost:8081/api/eda/v1/status/
+        if: ${{ matrix.SCENARIO == 'default' }}
+
+      - name: Test EDA API via UI k8s service
         run: |
           kubectl port-forward service/eda-demo-ui 8080:80 &
           sleep 1
           curl -s http://localhost:8080/api/eda/v1/status/
-        if: ${{ matrix.SCENARIO != 'ingress' }}
+        if: ${{ matrix.SCENARIO != 'default' }}
 
       - name: Test EDA API via k8s ingress
         run: |

--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -66,6 +66,9 @@ spec:
                 description: Configure no_log for no log tasks
                 type: boolean
                 default: true
+              ui_disabled:
+                description: Disable the UI for a headless EDA deployment (only API endpoints)
+                type: boolean
               image:
                 description: Registry path to API container image to use
                 type: string

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -64,6 +64,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Disable UI (Headless EDA including only API endpoints)
+        path: ui_disabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Clean up backup when EDABackup is deleted
         path: clean_backup_on_delete
         x-descriptors:

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -6,6 +6,7 @@ kind: 'EDA'
 api_version: '{{ deployment_type }}.ansible.com/v1alpha1'
 
 no_log: true
+ui_disabled: false
 
 image_pull_policy: IfNotPresent
 image_pull_secrets: []

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -19,7 +19,7 @@
     definition: "{{ lookup('template', 'eda.configmap.yaml.j2') }}"
     wait: yes
 
-- name: Apply deployment resources
+- name: Apply Backend deployment resources
   k8s:
     apply: yes
     definition: "{{ lookup('template', item + '.yaml.j2') }}"
@@ -28,12 +28,27 @@
     - 'eda-api.configmap'
     - 'eda-api.service'
     - 'eda-api.deployment'
-    - 'eda-ui.service'
-    - 'eda-ui.deployment'
-    - 'eda-ui.ingress'
     - 'eda-default-worker.deployment'
     - 'eda-activation-worker.deployment'
     - 'eda-scheduler.deployment'
+
+- name: Apply UI deployment resources if UI is enabled
+  k8s:
+    state: "{{ 'present' if not ui_disabled else 'absent' }}"
+    definition: "{{ lookup('template', item + '.yaml.j2') }}"
+    wait: no
+  loop:
+    - 'eda-ui.service'
+    - 'eda-ui.deployment'
+    - 'eda-ui.ingress'
+
+- name: Apply API Route or Ingress if UI is disabled
+  k8s:
+    state: "{{ 'present' if ui_disabled else 'absent' }}"
+    definition: "{{ lookup('template', item + '.yaml.j2') }}"
+    wait: no
+  loop:
+    - 'eda-api.ingress'
 
 - name: Remove legacy EDA worker deployment
   k8s:

--- a/roles/eda/templates/eda-api.ingress.yaml.j2
+++ b/roles/eda/templates/eda-api.ingress.yaml.j2
@@ -1,0 +1,76 @@
+{% if ingress_type|lower == "ingress" %}
+---
+{% if ingress_api_version is defined %}
+apiVersion: '{{ ingress_api_version }}'
+{% endif %}
+kind: Ingress
+metadata:
+  name: '{{ ansible_operator_meta.name }}-api-ingress'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+{% if ingress_annotations %}
+  annotations:
+    {{ ingress_annotations | indent(width=4) }}
+{% endif %}
+spec:
+{% if ingress_class_name %}
+  ingressClassName: '{{ ingress_class_name }}'
+{% endif %}
+  rules:
+    - http:
+        paths:
+          - path: '{{ ingress_path }}'
+            pathType: '{{ ingress_path_type }}'
+            backend:
+              service:
+                name: '{{ ansible_operator_meta.name }}-api'
+                port:
+                  number: 8000
+{% if hostname %}
+      host: {{ hostname }}
+{% endif %}
+{% if ingress_tls_secret %}
+  tls:
+    - hosts:
+        - {{ hostname }}
+      secretName: {{ ingress_tls_secret }}
+{% endif %}
+{% endif %}
+
+{% if ingress_type|lower == "route" %}
+---
+{% if route_api_version is defined %}
+apiVersion: '{{ route_api_version }}'
+{% endif %}
+kind: Route
+metadata:
+  name: '{{ ansible_operator_meta.name }}-api'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+spec:
+{% if route_host != '' %}
+  host: {{ route_host }}
+{% endif %}
+  port:
+    targetPort: '{{ (route_tls_termination_mechanism | lower == "passthrough") | ternary("https", "http") }}'
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: {{ route_tls_termination_mechanism | lower }}
+{% if route_tls_termination_mechanism | lower == 'edge' and route_tls_secret != '' %}
+    key: |-
+{{ route_tls_key | indent(width=6, first=True) }}
+    certificate: |-
+{{ route_tls_crt | indent(width=6, first=True) }}
+{% if route_ca_crt is defined %}
+    caCertificate: |-
+{{ route_ca_crt | indent(width=6, first=True) }}
+{% endif %}
+{% endif %}
+  to:
+    kind: Service
+    name: {{ ansible_operator_meta.name }}-api
+    weight: 100
+  wildcardPolicy: None
+{% endif %}


### PR DESCRIPTION
Follow-up work for: https://github.com/ansible/eda-server-operator/pull/216

For headless EDA installs, the user can set `ui_disabled: true` and the UI deployment and service will not be applied.  Instead, a route/ingress for the API deployment and service will be created. 