### PR TITLE
(WIP) Fix: Do not cause operator failure when 'bundle_cacert_secret' is incorrectly specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ kustomization.yaml
 *.swo
 *~
 .vscode/
+venv/

--- a/roles/eda/tasks/set_bundle_cacert.yml
+++ b/roles/eda/tasks/set_bundle_cacert.yml
@@ -11,4 +11,4 @@
   set_fact:
     bundle_ca_crt: '{{ bundle_cacert["resources"][0]["data"]["bundle-ca.crt"] | b64decode }}'
   no_log: "{{ no_log }}"
-  when: '"bundle-ca.crt" in bundle_cacert["resources"][0]["data"]'
+  when: 'bundle_cacert["resources"] | length > 0 and "bundle-ca.crt" in bundle_cacert["resources"][0]["data"]'


### PR DESCRIPTION
This PR is attempts to add the logic to avoid failures when a `bundle_cacert_secret` is incorrectly specified in the PR.

Wondering if we should also add a `Condition` to the Status of our EDA resource to specify this? And if so, do we have any existing patterns for this?