### PR TITLE
Rework URL status task to look for the API or the UI route

### DIFF
--- a/roles/eda/tasks/update_status.yml
+++ b/roles/eda/tasks/update_status.yml
@@ -41,7 +41,9 @@
         api_version: 'route.openshift.io/v1'
         kind: Route
         namespace: '{{ ansible_operator_meta.namespace }}'
-        name: '{{ ansible_operator_meta.name }}'
+        name: '{{ ansible_operator_meta.name }}*'
+        label_selectors:
+          - 'app.kubernetes.io/name={{ ansible_operator_meta.name }}' # matches ui and api route, there should only ever be one or the other
       register: route_url
 
     - name: Update URL status


### PR DESCRIPTION
Rework URL status task to look for the API or the UI route
- If the UI route does not exist, the API route (appended -api) should be used.

