### PR TITLE
Set port to 8000 for api targetPort on API Route

### DIFF
--- a/roles/eda/templates/eda-api.ingress.yaml.j2
+++ b/roles/eda/templates/eda-api.ingress.yaml.j2
@@ -54,7 +54,7 @@ spec:
   host: {{ route_host }}
 {% endif %}
   port:
-    targetPort: '{{ (route_tls_termination_mechanism | lower == "passthrough") | ternary("https", "http") }}'
+    targetPort: '{{ api_nginx_port }}'
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: {{ route_tls_termination_mechanism | lower }}


### PR DESCRIPTION
Without this change, the route is unavailable when `ui_disabled: true`, with this change I can see the api.

![image](https://github.com/user-attachments/assets/f49cbff7-fe4b-4292-b09c-4454fd4c09f1)
