### PR TITLE
Move bundle_ca_crt conditional to not include static files

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -153,10 +153,10 @@ spec:
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}
-{% if bundle_ca_crt  %}
         volumeMounts:
           - name: static-files
             mountPath: {{ static_path }}
+{% if bundle_ca_crt  %}
       - name: configure-bundle-ca-cert
         image: {{ _image }}
         imagePullPolicy: '{{ image_pull_policy }}'


### PR DESCRIPTION
Prior to this change, if the bundle ca secret was not configured, the api endpoints would not be rendered.

This is because the collectstatic management command would be a noop because the static directory was not created by the volumeMount.