### PR TITLE
Add Parameter for EDA Webhook Base URL in Configuration Files

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -40,6 +40,10 @@ spec:
                 type: array
                 items:
                   type: string
+              public_base_url:
+                description: Public base URL for EDA
+                type: string
+                default: ''
               automation_server_url:
                 description: URL of the AWX automation host to run ansible jobs against
                 type: string

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -186,6 +186,10 @@ spec:
       kind: EDA
       name: edas.eda.ansible.com
       specDescriptors:
+      - displayName: Public Base URL
+        path: public_base_url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Automation Server URL
         path: automation_server_url
         x-descriptors:

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -12,7 +12,7 @@ data:
   EDA_DEPLOYMENT_TYPE: "k8s"
 
   # Public URL
-  EDA_WEBHOOK_BASE_URL: "{{ public_base_url }}"
+  EDA_WEBHOOK_BASE_URL: "{{ public_base_url.rstrip('/') }}/{{ eda_webhook_prefix_path.lstrip('/') }}"
 
   # EDA Server
   EDA_CONTROLLER_URL: "{{ automation_server_url }}"

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -11,6 +11,9 @@ data:
   # Operator specific settings
   EDA_DEPLOYMENT_TYPE: "k8s"
 
+  # Public URL
+  EDA_WEBHOOK_BASE_URL: "{{ public_base_url }}"
+
   # EDA Server
   EDA_CONTROLLER_URL: "{{ automation_server_url }}"
   EDA_CONTROLLER_SSL_VERIFY: "{{ automation_server_ssl_verify | default('yes')}}"


### PR DESCRIPTION
This PR adds a parameter to config/crd/bases/eda and templates this into the EDA settings configmap as EDA_WEBHOOK_BASE_URL.