### PR TITLE
Make default webhook host different from ui webhook host if ingress i…

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - SCENARIO: default
           - SCENARIO: externaldb
-          # - SCENARIO: ingress  # TODO: This scenario currently fails because ui and webhook ingress cannot have the same host and path in minikube nginx ingress controller
+          - SCENARIO: ingress
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
         if: always()
         run: |
           echo ::group::OPERATOR_LOGS
-          kubectl logs -l control-plane=controller-manager --tail=10000 || true
+          kubectl logs -l control-plane=controller-manager --tail=20000 || true
           echo ::endgroup::
           echo ::group::POSTGRES_LOGS
           kubectl logs -l app.kubernetes.io/component=database --tail=1000 || true

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -42,7 +42,11 @@
     wait: no
   loop:
     - 'eda-webhook.ingress'
-  when: not ui_disabled
+  when:
+    - (service_type | lower) == 'route' or ((service_type | lower) == 'ingress' and ui_disabled)
+  # Always runs if service_type: Route
+  # If service_type: Ingress, only run if UI is disabled
+  # If UI is enabled, the webhook ingress is handled by the UI ingress via multiple pathes
 
 - name: Apply UI deployment resources if UI is enabled
   k8s:

--- a/roles/eda/templates/eda-ui.ingress.yaml.j2
+++ b/roles/eda/templates/eda-ui.ingress.yaml.j2
@@ -27,6 +27,13 @@ spec:
                 name: '{{ ansible_operator_meta.name }}-ui'
                 port:
                   number: 80
+          - path: '{{ eda_webhook_prefix_path }}'
+            pathType: '{{ ingress_path_type }}'
+            backend:
+              service:
+                name: '{{ ansible_operator_meta.name }}-webhook'
+                port:
+                  number: 8000
 {% if hostname %}      
       host: {{ hostname }}
 {% endif %}      

--- a/roles/eda/templates/eda-webhook.ingress.yaml.j2
+++ b/roles/eda/templates/eda-webhook.ingress.yaml.j2
@@ -20,14 +20,14 @@ spec:
   rules:
     - http:
         paths:
-          - path: '/'
+          - path: '{{ eda_webhook_prefix_path }}'
             pathType: '{{ ingress_path_type }}'
             backend:
               service:
                 name: '{{ ansible_operator_meta.name }}-webhook'
                 port:
                   number: 8000
-{% if hostname %}      
+{% if hostname %}
       host: {{ hostname }}
 {% endif %}      
 {% if ingress_tls_secret %}

--- a/up.sh
+++ b/up.sh
@@ -109,7 +109,7 @@ if $DEV_TAG_PUSH ; then
 fi
 
 # -- Deploy Operator
-make deploy IMG=$IMG NAMESPACE=$NAMESPACE
+make deploy IMG=$IMG:$TAG NAMESPACE=$NAMESPACE
 
 
 # -- Create CR


### PR DESCRIPTION
Make default webhook host different from ui webhook host if ingress is used.

CI was failing because the webhook admission validator fails on certain clusters if the host of an ingress is the same as the host value of another ingress.  Now that we have 2 ingress (ui and webhook), that is a problem.  

This also makes the webhook ingress host customization. 