### PR TITLE
Fix webhook prefix configuration

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -432,7 +432,7 @@ spec:
               webhook:
                 description: Defines desired state of eda-webhook resources
                 properties:
-                  eda_webhook_prefix:
+                  prefix:
                     description: Prefix for the webhook
                     type: string
                   gunicorn_workers:

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -384,7 +384,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Webhook custom prefix path
         displayName: Webhook prefix path
-        path: webhook_prefix
+        path: prefix
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: The number of gunicorn workers for the Webhook.

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -74,7 +74,7 @@ _scheduler:
 
 webhook: {}
 _webhook:
-  webhook_prefix: /eda-webhook
+  prefix: /eda-webhook
   gunicorn_workers: 2
   replicas: 1
   resource_requirements:

--- a/roles/eda/templates/eda-ui.ingress.yaml.j2
+++ b/roles/eda/templates/eda-ui.ingress.yaml.j2
@@ -27,7 +27,7 @@ spec:
                 name: '{{ ansible_operator_meta.name }}-ui'
                 port:
                   number: 80
-          - path: '{{ eda_webhook_prefix_path }}'
+          - path: '/'
             pathType: '{{ ingress_path_type }}'
             backend:
               service:

--- a/roles/eda/templates/eda-webhook.ingress.yaml.j2
+++ b/roles/eda/templates/eda-webhook.ingress.yaml.j2
@@ -20,7 +20,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: '{{ eda_webhook_prefix_path }}'
+          - path: '/'
             pathType: '{{ ingress_path_type }}'
             backend:
               service:

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -11,9 +11,11 @@ data:
   # Operator specific settings
   EDA_DEPLOYMENT_TYPE: "k8s"
 
+  {% if public_base_url and eda_webhook_prefix_path %}
   # Public URL
   EDA_WEBHOOK_BASE_URL: "{{ public_base_url.rstrip('/') }}/{{ eda_webhook_prefix_path.lstrip('/') }}"
   EDA_WEBHOOK_MTLS_BASE_URL: "{{ public_base_url.rstrip('/') }}/mtls/{{ eda_webhook_prefix_path.lstrip('/') }}"
+  {% endif %}
 
   # EDA Server
   EDA_CONTROLLER_URL: "{{ automation_server_url }}"

--- a/roles/eda/vars/main.yml
+++ b/roles/eda/vars/main.yml
@@ -10,7 +10,7 @@ media_dir: /var/lib/eda/files
 static_path: /var/lib/eda/static
 bundle_ca_crt: ''
 
-eda_webhook_prefix_path: "{{ eda_webhook_prefix | default('/eda-webhooks') }}"
+eda_webhook_prefix_path: "{{ webhook.prefix | default('/eda-webhooks') }}"
 webhook_nginx_port: 8000
 webhook_server_name: "{{ ansible_operator_meta.name }}-webhook"
 webhook_django_port: 8002


### PR DESCRIPTION
Ironing out configuration issues.  

Still need to figure out how to auto-set EDA_WEBHOOK url style env vars for ingress... 
Right now it's configurable by public_base_url and webhooks.prefix