### PR TITLE
Expose MQ_TLS setting for activating TLS

### DIFF
--- a/docs/user-guide/redis-configuration.md
+++ b/docs/user-guide/redis-configuration.md
@@ -2,7 +2,7 @@
 
 #### Redis Version
 
-The default PostgreSQL version for the version of EDA bundled with the latest version of the eda-server-operator is Redis 6.
+The default Redis version for the version of EDA bundled with the latest version of the eda-server-operator is Redis 6.
 
 #### External Redis Service
 
@@ -20,6 +20,7 @@ metadata:
 stringData:
   host: <external ip or url resolvable by the cluster>
   port: <external port, this usually defaults to 6370>
+  redis_tls: <true / false to enable TLS>
   database: <desired database name>
   cluster_endpoint: <optional - see Redis Cluster section>
   username: <username to connect as>

--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -202,6 +202,12 @@ spec:
             secretKeyRef:
               name: '{{ redis_config_secret }}'
               key: password
+        - name: EDA_MQ_TLS
+          valueFrom:
+            secretKeyRef:
+              name: '{{ redis_config_secret }}'
+              key: redis_tls
+              optional: true
         - name: EDA_MQ_REDIS_HA_CLUSTER_HOSTS
           valueFrom:
             secretKeyRef:

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -249,6 +249,12 @@ spec:
             secretKeyRef:
               name: '{{ redis_config_secret }}'
               key: password
+        - name: EDA_MQ_TLS
+          valueFrom:
+            secretKeyRef:
+              name: '{{ redis_config_secret }}'
+              key: redis_tls
+              optional: true
         - name: EDA_MQ_REDIS_HA_CLUSTER_HOSTS
           valueFrom:
             secretKeyRef:
@@ -338,6 +344,12 @@ spec:
             secretKeyRef:
               name: '{{ redis_config_secret }}'
               key: password
+        - name: EDA_MQ_TLS
+          valueFrom:
+            secretKeyRef:
+              name: '{{ redis_config_secret }}'
+              key: redis_tls
+              optional: true
         - name: EDA_MQ_REDIS_HA_CLUSTER_HOSTS
           valueFrom:
             secretKeyRef:

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -202,6 +202,12 @@ spec:
             secretKeyRef:
               name: '{{ redis_config_secret }}'
               key: password
+        - name: EDA_MQ_TLS
+          valueFrom:
+            secretKeyRef:
+              name: '{{ redis_config_secret }}'
+              key: redis_tls
+              optional: true
         - name: EDA_MQ_REDIS_HA_CLUSTER_HOSTS
           valueFrom:
             secretKeyRef:

--- a/roles/eda/templates/eda-event-stream.deployment.yaml.j2
+++ b/roles/eda/templates/eda-event-stream.deployment.yaml.j2
@@ -202,6 +202,12 @@ spec:
             secretKeyRef:
               name: '{{ redis_config_secret }}'
               key: password
+        - name: EDA_MQ_TLS
+          valueFrom:
+            secretKeyRef:
+              name: '{{ redis_config_secret }}'
+              key: redis_tls
+              optional: true
         - name: EDA_MQ_REDIS_HA_CLUSTER_HOSTS
           valueFrom:
             secretKeyRef:

--- a/roles/eda/templates/eda-scheduler.deployment.yaml.j2
+++ b/roles/eda/templates/eda-scheduler.deployment.yaml.j2
@@ -170,6 +170,12 @@ spec:
             secretKeyRef:
               name: '{{ redis_config_secret }}'
               key: password
+        - name: EDA_MQ_TLS
+          valueFrom:
+            secretKeyRef:
+              name: '{{ redis_config_secret }}'
+              key: redis_tls
+              optional: true
         - name: EDA_MQ_REDIS_HA_CLUSTER_HOSTS
           valueFrom:
             secretKeyRef:

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -26,7 +26,6 @@ data:
   # EDA Server
   EDA_ALLOWED_HOSTS: "['*']"
   EDA_CSRF_TRUSTED_ORIGINS: "http://{{ api_server_name }}:{{ api_nginx_port }}"
-  EDA_MQ_HOST: "{{ ansible_operator_meta.name }}-redis-svc"
   EDA_WEBSOCKET_BASE_URL: "ws://{{ websocket_server_name }}:{{ websocket_port }}"
   EDA_WEBSOCKET_TOKEN_BASE_URL: "http://{{ api_server_name }}:{{ api_nginx_port }}"
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"


### PR DESCRIPTION
This will expose the new MQ_TLS setting to force the use of TLS on Redis connections.

This requires this PR to be merged:  https://github.com/ansible/eda-server/pull/1033