### PR TITLE
Use the same Route name for the api endpoints when the UI is disabled

### DIFF
--- a/roles/eda/templates/eda-api.ingress.yaml.j2
+++ b/roles/eda/templates/eda-api.ingress.yaml.j2
@@ -45,7 +45,7 @@ apiVersion: '{{ route_api_version }}'
 {% endif %}
 kind: Route
 metadata:
-  name: '{{ ansible_operator_meta.name }}-api'
+  name: '{{ ansible_operator_meta.name }}'
   namespace: '{{ ansible_operator_meta.namespace }}'
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}


### PR DESCRIPTION
Use the same Route name for the api endpoints when the UI is disable for backwards compatibility.