### PR TITLE
OCP Redis failover workaround

### DIFF
--- a/roles/redis/tasks/check_default_config.yml
+++ b/roles/redis/tasks/check_default_config.yml
@@ -13,4 +13,5 @@
   ansible.builtin.set_fact:
     redis_type: "{{ _redis_configuration['resources'][0]['data']['type'] | default('') | b64decode }}"
     redis_config_secret: "{{ _redis_configuration['resources'][0]['metadata']['name'] }}"
+    redis_mode: "{{ _redis_configuration['resources'][0]['data']['redis_mode'] | default('') | b64decode }}"
   when: _redis_configuration['resources'][0] is defined

--- a/roles/redis/tasks/check_external_config.yml
+++ b/roles/redis/tasks/check_external_config.yml
@@ -16,4 +16,5 @@
   ansible.builtin.set_fact:
     redis_type: 'unmanaged'
     redis_config_secret: "{{ _redis_configuration['resources'][0]['metadata']['name'] }}"
+    redis_mode: "{{ _redis_configuration['resources'][0]['data']['redis_mode'] | default('') | b64decode }}"
   when: _redis_configuration['resources'][0] is defined

--- a/roles/redis/tasks/create_default_config.yml
+++ b/roles/redis/tasks/create_default_config.yml
@@ -12,4 +12,5 @@
   ansible.builtin.set_fact:
     redis_type: "managed"
     redis_config_secret: "{{ ansible_operator_meta.name }}-redis-configuration"
+    redis_mode: "standalone"
   when: result is succeeded

--- a/roles/redis/tasks/ensure_eda_workers_redis_connectivity.yml
+++ b/roles/redis/tasks/ensure_eda_workers_redis_connectivity.yml
@@ -14,14 +14,17 @@
     label_selectors:
       - "app.kubernetes.io/component={{ item }}"
   loop: "{{ _eda_workers_deployment_list }}"
+  no_log: "{{ no_log }}"
   register: _eda_worker_pod_info
 
 - name: "Check if restart is required"
   vars:
-    _eda_worker_container_status: "{{ item.resources[0].status.containerStatuses[0].state.waiting.reason | default('Running') }}"
+    _eda_worker_crashloopback_check: "{{ item.resources[0].status.containerStatuses[0].state.waiting.reason | default('Running') }}"
+    _eda_worker_completed_check: "{{ item.resources[0].status.containerStatuses[0].lastState.terminated.reason | default('Running') }}"
   ansible.builtin.set_fact:
     _eda_workers_restart_required: true
-  when: _eda_worker_container_status == 'CrashLoopBackOff'
+  when: _eda_worker_crashloopback_check == 'CrashLoopBackOff' or _eda_worker_completed_check == 'Completed'
+  no_log: "{{ no_log }}"
   loop: "{{ _eda_worker_pod_info.results }}"
 
 - name: "Restart all EDA worker pods if restart is required"
@@ -32,4 +35,5 @@
     label_selectors:
       - "app.kubernetes.io/component={{ item }}"
     state: absent
+  no_log: "{{ no_log }}"
   loop: "{{ _eda_workers_deployment_list }}"

--- a/roles/redis/tasks/ensure_eda_workers_redis_connectivity.yml
+++ b/roles/redis/tasks/ensure_eda_workers_redis_connectivity.yml
@@ -1,0 +1,35 @@
+---
+- name: "Set initial facts"
+  ansible.builtin.set_fact:
+    _eda_workers_restart_required: false
+    _eda_workers_deployment_list:
+      - "eda-activation-worker"
+      - "eda-default-worker"
+      - "eda-scheduler"
+
+- name: "Get EDA worker deployments pods info"
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/component={{ item }}"
+  loop: "{{ _eda_workers_deployment_list }}"
+  register: _eda_worker_pod_info
+
+- name: "Check if restart is required"
+  vars:
+    _eda_worker_container_status: "{{ item.resources[0].status.containerStatuses[0].state.waiting.reason | default('Running') }}"
+  ansible.builtin.set_fact:
+    _eda_workers_restart_required: true
+  when: _eda_worker_container_status == 'CrashLoopBackOff'
+  loop: "{{ _eda_worker_pod_info.results }}"
+
+- name: "Restart all EDA worker pods if restart is required"
+  when: _eda_workers_restart_required
+  kubernetes.core.k8s:
+    kind: Pod
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/component={{ item }}"
+    state: absent
+  loop: "{{ _eda_workers_deployment_list }}"

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -19,3 +19,8 @@
 - name: Create a managed Redis deployment
   ansible.builtin.include_tasks: create_managed_redis.yml
   when: redis_type == 'managed'
+
+# REDIS FAILOVER WORKAROUND
+- name: Ensure EDA Redis is in a functional state
+  ansible.builtin.include_tasks: ensure_eda_workers_redis_connectivity.yml
+  when: redis_mode == 'cluster'

--- a/roles/redis/templates/redis.secret.yaml.j2
+++ b/roles/redis/templates/redis.secret.yaml.j2
@@ -17,3 +17,4 @@ stringData:
   port: '6379'
   host: {{ ansible_operator_meta.name }}-redis-svc
   type: 'managed'
+  redis_mode: 'standalone'


### PR DESCRIPTION
When Redis is running in cluster mode, if a given EDA worker pod is detected with `crashloopbackoff` status, trigger the restart of all EDA worker pods.