### PR TITLE
Fix CI & PR check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Test EDA API via k8s ingress
         run: |
-          IP=$(kubectl get ingress -n eda eda-demo-ingress -o json | jq .status.loadBalancer.ingress[0].ip -r)
+          IP=$(kubectl get ingress -n eda eda-demo-ui-ingress -o json | jq .status.loadBalancer.ingress[0].ip -r)
           curl -s http://${IP}:80/api/eda/v1/status/
         if: ${{ matrix.SCENARIO == 'ingress' }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Test EDA API via k8s ingress
         run: |
-          IP=$(kubectl get ingress -n eda eda-demo-ingress -o json | jq .status.loadBalancer.ingress[0].ip -r)
+          IP=$(kubectl get ingress -n eda eda-demo-ui-ingress -o json | jq .status.loadBalancer.ingress[0].ip -r)
           curl -s http://${IP}:80/api/eda/v1/status/
         if: ${{ matrix.SCENARIO == 'ingress' }}
 


### PR DESCRIPTION
ingress was renamed to `{{ resource_name }}-ui-ingress`. Adjust CI accordingly as a result of this rename - https://github.com/ansible/eda-server-operator/commit/a32465c06875226c427e7cfb4bf0b877b0846fde