### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Wait for the EDA API pod to be ready
         run: |
-          kubectl wait --for condition=Ready --timeout=-1s -l app.kubernetes.io/component=eda-api
+          kubectl wait --for condition=Ready pod --timeout=-1s -l app.kubernetes.io/component=eda-api
 
       - name: Test EDA API via API k8s service
         run: |


### PR DESCRIPTION
The `wait for EDA API pod to be ready` task is currently failing with the error - 

```
error: at least one resource must be specified to use a selector
```

Adding the resource type here ensures it can be found when querying by label. This failure can be seen [here](https://github.com/ansible/eda-server-operator/actions/runs/11442918937)

Successful run using this fix is shown here - https://github.com/ansible/eda-server-operator/actions/runs/11448660579