### PR TITLE
Fix Redirect Page logo and favicon path

### DIFF
--- a/roles/eda/templates/redirect-page.configmap.html.j2
+++ b/roles/eda/templates/redirect-page.configmap.html.j2
@@ -14,11 +14,11 @@ data:
         <title>Redirecting to Ansible Automation Platform</title>
 
         <!-- Favicon links -->
-        <link rel="icon" type="image/x-icon" href="static/rest_framework/docs/img/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/api/eda/static/media/favicon.ico">
 
         <!-- Link to DRF's CSS -->
-        <link rel="stylesheet" type="text/css" href="static/rest_framework/css/bootstrap.min.css">
-        <link rel="stylesheet" type="text/css" href="static/rest_framework/css/bootstrap-theme.min.css">
+        <link rel="stylesheet" type="text/css" href="/api/eda/static/rest_framework/css/bootstrap.min.css">
+        <link rel="stylesheet" type="text/css" href="/api/eda/static/rest_framework/css/bootstrap-theme.min.css">
 
         <style>
             body {
@@ -59,7 +59,7 @@ data:
     <body>
         <!-- Banner Section with Brand Logo -->
         <div class="banner">
-            <img class="logo" src="/static/media/aap-logo.svg" alt="Brand Logo">
+            <img class="logo" src="/api/eda/static/media/aap-logo.svg" alt="Brand Logo">
         </div>
 
         <h2>Redirecting to Ansible Automation Platform...</h2>
@@ -71,7 +71,7 @@ data:
         </p>
 
         <!-- Include any additional scripts if needed -->
-        <script src="static/rest_framework/js/jquery-3.5.1.min.js"></script>
-        <script src="static/rest_framework/js/bootstrap.min.js"></script>
+        <script src="/api/eda/static/rest_framework/js/jquery-3.5.1.min.js"></script>
+        <script src="/api/eda/static/rest_framework/js/bootstrap.min.js"></script>
     </body>
     </html>


### PR DESCRIPTION
Because static files are served up at `/api/eda/static` in the nginx conf, some of the paths for the logo and favicon on the redirect page need to be updated.