### PR TITLE
Reorder nginx container resource requirements in template to fix syntax

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -399,10 +399,10 @@ spec:
             mountPath: /var/cache/nginx
           - name: nginx-run
             mountPath: /var/run
-      restartPolicy: Always
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}
+      restartPolicy: Always
       volumes:
 {% if not ui_disabled %}
         - name: static-files


### PR DESCRIPTION
The api-deployment template does not apply successfully because the resource requirements are being templated in outside of the nginx block in the deployment yaml.  It just needs to be moved up a line and it will work.