### PR TITLE
Add ci check running deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,15 @@ jobs:
           kubectl wait --for condition=Successful --timeout=600s -f .ci/eda_v1alpha1_eda.${{ matrix.SCENARIO }}.ci.yaml || \
           (echo "Reconciliation loop did not converge within 10 minutes" && kubectl describe -f .ci/eda_v1alpha1_eda.${{ matrix.SCENARIO }}.ci.yaml && exit 1)
 
+      - name: Check that the EDA demo is running
+        run: |
+          kubectl wait --for condition=Running --timeout=-1s -l app.kubernetes.io/component=eda-default-worker
+          kubectl wait --for condition=Running --timeout=-1s -l app.kubernetes.io/component=eda-activation-worker
+          kubectl wait --for condition=Running --timeout=-1s -l app.kubernetes.io/component=eda-scheduler
+          kubectl wait --for condition=Running --timeout=-1s -l app.kubernetes.io/component=eda-api
+          kubectl wait --for condition=Running --timeout=-1s -l app.kubernetes.io/component=database
+          kubectl wait --for condition=Running --timeout=-1s -l app.kubernetes.io/component=cache
+
       - name: Backup EDA demo
         run: |
           kubectl apply -f .ci/eda_v1alpha1_edabackup.ci.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,11 @@ jobs:
           curl -s http://${IP}:80/api/eda/v1/status/
         if: ${{ matrix.SCENARIO == 'ingress' }}
 
+      - name: Check that the reconciliation loop has converged
+        run: |
+          kubectl wait --for condition=Successful --timeout=600s -f .ci/eda_v1alpha1_eda.${{ matrix.SCENARIO }}.ci.yaml || \
+          (echo "Reconciliation loop did not converge within 10 minutes" && kubectl describe -f .ci/eda_v1alpha1_eda.${{ matrix.SCENARIO }}.ci.yaml && exit 1)
+
       - name: Backup EDA demo
         run: |
           kubectl apply -f .ci/eda_v1alpha1_edabackup.ci.yaml

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -399,10 +399,10 @@ spec:
             mountPath: /var/cache/nginx
           - name: nginx-run
             mountPath: /var/run
-      restartPolicy: Always
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}
+      restartPolicy: Always
       volumes:
 {% if not ui_disabled %}
         - name: static-files


### PR DESCRIPTION
This checks that the deployments are all in running state before moving on to the backup and restore blocks in CI checks.