### PR TITLE
Remove x-kubernetes-preserve-unknown-fields field from schema so explain params work

### DIFF
--- a/config/crd/bases/eda.ansible.com_edabackups.yaml
+++ b/config/crd/bases/eda.ansible.com_edabackups.yaml
@@ -38,7 +38,6 @@ spec:
             type: object
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
             required:
             - deployment_name
             properties:

--- a/config/crd/bases/eda.ansible.com_edarestores.yaml
+++ b/config/crd/bases/eda.ansible.com_edarestores.yaml
@@ -38,7 +38,6 @@ spec:
             type: object
           spec:
             type: object
-            x-kubernetes-preserve-unknown-fields: true
             properties:
               backup_source:
                 description: Backup source


### PR DESCRIPTION
Remove x-kubernetes-preserve-unknown-fields field from schema so that users can run:

```
oc explain EDA.spec
```


When I remove this line under EDA.spec in the CRD, the oc explain works:

```
x-kubernetes-preserve-unknown-fields: true
```

When this line is removed, or set to false (default), then parameters that are not explicitly defined on the CRD schema will not be accepted and the k8s validator will automatically (and silently) omit any parameters that it does not know about when the CRD is modified / created.



##### ADDITIONAL INFORMATION

In the case of EDA, I think that should be fine because all accepted params are defined in the CRD schema already.

The `spec.extra_settings` param will still set that preserve-unknown-fields config to true for just extra_settings, so that's OK.
