### PR TITLE
removing minimum replicas to allow scaling down of deployment

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -112,7 +112,6 @@ spec:
                       Default: 1'
                     format: int32
                     default: 1
-                    minimum: 1
                     nullable: true
                     type: integer
                   resource_requirements:
@@ -453,7 +452,6 @@ spec:
                       Default: 1'
                     format: int32
                     default: 1
-                    minimum: 1
                     nullable: true
                     type: integer
                   resource_requirements:


### PR DESCRIPTION
Currently the replicas are hardcoded in the crd to have a minimum of 1 which prevents users from being able to scale down the deployment.