### PR TITLE
idle_deployment - Scale down deployments to put EDA into an idle state:

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2428,6 +2428,9 @@ spec:
                     description: 'Defines Redis Deployment replicas'
                     format: int32
                     type: integer
+                    default: 1
+                    minimum: 0
+                    maximum: 1
                   node_selector:
                     additionalProperties:
                       type: string
@@ -2822,6 +2825,9 @@ spec:
                 type: string
               force_drop_db:
                 description: Force drop the database before restoring. USE WITH CAUTION!
+                type: boolean
+              idle_deployment:
+                description: Scale down deployments to put EDA into an idle state
                 type: boolean
           status:
             description: Status defines the observed state of EDA

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -59,6 +59,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Scale down deployments to put EDA into an idle state
+        displayName: Idle EDA
+        path: idle_deployment
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: No Log Configuration
         path: no_log
         x-descriptors:

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -168,3 +168,6 @@ admin_password_secret: ''
 
 # Disable UI container's nginx ipv6 listener
 ipv6_disabled: false
+
+# idle_deployment - Scale down deployments to put EDA into an idle state
+idle_deployment: false

--- a/roles/eda/tasks/idle_deployment.yml
+++ b/roles/eda/tasks/idle_deployment.yml
@@ -1,0 +1,93 @@
+---
+- name: Scale down EDA Deployments
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ item }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      spec:
+        replicas: 0
+  loop:
+    - '{{ ansible_operator_meta.name }}-activation-worker'
+    - '{{ api_server_name }}'
+    - '{{ ansible_operator_meta.name }}-default-worker'
+    - '{{ event_stream_server_name }}'
+    - '{{ ansible_operator_meta.name }}-scheduler'
+
+- name: Scale down EDA ui if enabled
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ ansible_operator_meta.name }}-ui"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      spec:
+        replicas: 0
+  when: not ui_disabled
+
+- name: Check for an external Redis cache
+  ansible.builtin.import_role:
+    name: redis
+    tasks_from: check_external_config
+  when: redis_type | length == 0 or redis_type == 'unmanaged'
+
+- name: Check for the default Redis configuration
+  ansible.builtin.import_role:
+    name: redis
+    tasks_from: check_default_config
+  when: redis_type | length == 0 or redis_type == 'managed'
+
+- name: Create a default Redis configuration
+  ansible.builtin.import_role:
+    name: redis
+    tasks_from: create_default_config
+  when: redis_type | length == 0
+
+- name: Scale down Redis Deployment
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ ansible_operator_meta.name }}-redis"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      spec:
+        replicas: 0
+  when: redis_type == "managed"
+
+- name: Combine postgres default and custom vars for each component
+  ansible.builtin.import_role:
+    name: postgres
+    tasks_from: combine_defaults
+
+- name: Determine and set postgres configuration secret and variables
+  ansible.builtin.import_role:
+    name: postgres
+    tasks_from: set_configuration_secret
+
+- name: Set variables to be used in Postgres templates
+  ansible.builtin.import_role:
+    name: postgres
+    tasks_from: set_variables
+
+- name: Scale down PostgreSQL Statefulset
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: "{{ ansible_operator_meta.name }}-postgres-{{ supported_pg_version }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      spec:
+        replicas: 0
+  when: managed_database
+
+- name: End Playbook
+  ansible.builtin.meta: end_play

--- a/roles/eda/tasks/main.yml
+++ b/roles/eda/tasks/main.yml
@@ -8,6 +8,10 @@
   include_role:
     name: common
 
+- name: Idle EDA
+  include_tasks: idle_deployment.yml
+  when: idle_deployment | bool
+
 - name: Setup Redis
   include_role:
     name: redis

--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
     app.kubernetes.io/managed-by: 'eda-operator'
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: 'postgres-{{ supported_pg_version }}'


### PR DESCRIPTION
Added idle_deployment feature
Set redis replicas maximum to 1 (aligns with galaxy operator)
Added replicas: 1 to postgresql statefulset to ensure a single replica (needed to wake from idle)


**Patch EDA to put into idle state:**
`oc patch eda eda --type=merge -p '{"spec":{"idle_deployment":true}}'`

Result:

```
NAME                                                          READY   STATUS    RESTARTS   AGE
pod/eda-server-operator-controller-manager-5b4b58bdd7-dzfrs   2/2     Running   0          2m19s

NAME                                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/eda-activation-worker                    0/0     0            0           18h
deployment.apps/eda-api                                  0/0     0            0           18h
deployment.apps/eda-default-worker                       0/0     0            0           18h
deployment.apps/eda-event-stream                         0/0     0            0           18h
deployment.apps/eda-redis                                0/0     0            0           18h
deployment.apps/eda-scheduler                            0/0     0            0           18h
deployment.apps/eda-server-operator-controller-manager   1/1     1            1           18h
deployment.apps/eda-ui                                   0/0     0            0           18h

NAME                                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/eda-activation-worker-bccb8bd64                     0         0         0       18h
replicaset.apps/eda-api-7787696874                                  0         0         0       18h
replicaset.apps/eda-default-worker-5875f8d446                       0         0         0       18h
replicaset.apps/eda-event-stream-785dc54b8f                         0         0         0       18h
replicaset.apps/eda-redis-747596546f                                0         0         0       18h
replicaset.apps/eda-scheduler-cbfc48dd9                             0         0         0       18h
replicaset.apps/eda-server-operator-controller-manager-5b4b58bdd7   1         1         1       2m19s
replicaset.apps/eda-ui-88c5b59cf                                    0         0         0       18h

NAME                               READY   AGE
statefulset.apps/eda-postgres-15   0/0     18h

```

**Patch EDA again to bring out of idle state:**
`oc patch eda eda --type=merge -p '{"spec":{"idle_deployment":false}}'`

Result:
```
NAME                                                          READY   STATUS    RESTARTS   AGE
pod/eda-activation-worker-bccb8bd64-8mg8c                     1/1     Running   0          3m31s
pod/eda-activation-worker-bccb8bd64-jzh5m                     1/1     Running   0          3m31s
pod/eda-activation-worker-bccb8bd64-pjzkh                     1/1     Running   0          3m31s
pod/eda-api-7787696874-zqhwc                                  3/3     Running   0          3m33s
pod/eda-default-worker-5875f8d446-7s6kd                       1/1     Running   0          3m32s
pod/eda-default-worker-5875f8d446-kv47x                       1/1     Running   0          3m32s
pod/eda-event-stream-785dc54b8f-r9ztd                         2/2     Running   0          3m28s
pod/eda-postgres-15-0                                         1/1     Running   0          4m8s
pod/eda-redis-747596546f-6gfdf                                1/1     Running   0          4m13s
pod/eda-scheduler-cbfc48dd9-jls78                             1/1     Running   0          3m30s
pod/eda-scheduler-cbfc48dd9-klwj7                             1/1     Running   0          3m30s
pod/eda-server-operator-controller-manager-5b4b58bdd7-dzfrs   2/2     Running   0          7m54s
pod/eda-ui-88c5b59cf-2p9nm                                    1/1     Running   0          3m26s

NAME                                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/eda-activation-worker                    3/3     3            3           18h
deployment.apps/eda-api                                  1/1     1            1           18h
deployment.apps/eda-default-worker                       2/2     2            2           18h
deployment.apps/eda-event-stream                         1/1     1            1           18h
deployment.apps/eda-redis                                1/1     1            1           18h
deployment.apps/eda-scheduler                            2/2     2            2           18h
deployment.apps/eda-server-operator-controller-manager   1/1     1            1           19h
deployment.apps/eda-ui                                   1/1     1            1           18h

NAME                                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/eda-activation-worker-bccb8bd64                     3         3         3       18h
replicaset.apps/eda-api-7787696874                                  1         1         1       18h
replicaset.apps/eda-default-worker-5875f8d446                       2         2         2       18h
replicaset.apps/eda-event-stream-785dc54b8f                         1         1         1       18h
replicaset.apps/eda-redis-747596546f                                1         1         1       18h
replicaset.apps/eda-scheduler-cbfc48dd9                             2         2         2       18h
replicaset.apps/eda-server-operator-controller-manager-5b4b58bdd7   1         1         1       7m54s
replicaset.apps/eda-ui-88c5b59cf                                    1         1         1       18h

NAME                               READY   AGE
statefulset.apps/eda-postgres-15   1/1     18h
```