### PR TITLE
docs: add how to set event stream base url AAP-38345

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ spec:
 Optionally, it is also recommended to set `event_stream.prefix` with a non guessable value (for example an UUID) to avoid unwanted access to the event streams or DDOS attacks. 
 
 ```yaml
+apiVersion: eda.ansible.com/v1alpha1
+kind: EDA
+metadata:
+  name: eda
+spec:
+  event_stream:
+    prefix: "/f743d0ac-f9ca-11ef-9021-482ae389cd08"
+```
 
 ### Additional Advanced Configuration
 - [No Log](./docs/user-guide/advanced-configuration/no-log.md)

--- a/README.md
+++ b/README.md
@@ -218,6 +218,25 @@ spec:
   db_fields_encryption_secret: custom-eda-db-encryption-secret
 ```
 
+### Enable Event Streams
+In order to get working event streams in a standalone deployment, you need to set the application variable `EDA_EVENT_STREAM_BASE_URL` to the URL where EDA Server would be accessible from internet by external services. This value must contain the scheme, public hostname and event stream path (set by default to `/eda-event-streams`) This is needed to generate the correct URLs for the event streams.
+Example:
+
+```yaml
+apiVersion: eda.ansible.com/v1alpha1
+kind: EDA
+metadata:
+  name: eda
+spec:
+  extra_settings:
+    - setting: EDA_EVENT_STREAM_BASE_URL
+      value: "https://mypublicdomain.com/eda-event-streams"
+```
+
+Optionally, it is also recommended to set `event_stream.prefix` with a non guessable value (for example an UUID) to avoid unwanted access to the event streams or DDOS attacks. 
+
+```yaml
+
 ### Additional Advanced Configuration
 - [No Log](./docs/user-guide/advanced-configuration/no-log.md)
 - [EDA application settings](./docs/user-guide/advanced-configuration/settings.md)


### PR DESCRIPTION
By default, `EDA_EVENT_STREAM_BASE_URL` is not set, preventing event streams working in standalone deployments. This PR updates the documentation until a final solution to handle `public_base_url` is implemented. 

Ref: https://github.com/ansible/eda-server-operator/issues/265

Internal jira: https://issues.redhat.com/browse/AAP-38345