### PR TITLE
Fix topology_spread_constraints in deployment

### DIFF
--- a/roles/eda/templates/eda-event-stream.deployment.yaml.j2
+++ b/roles/eda/templates/eda-event-stream.deployment.yaml.j2
@@ -62,7 +62,7 @@ spec:
 {% endif %}
 {% if combined_event_stream.topology_spread_constraints is defined %}
       topologySpreadConstraints:
-        {{ combined_event_stream.topology_spread_constraints | indent(width=8) }}
+        {{ combined_event_stream.topology_spread_constraints | to_nice_yaml | indent(width=8) }}
 {% endif %}
       initContainers:
       - name: wait-for-migrations


### PR DESCRIPTION
Trying to use `spec.api.topology_spread_constraints` in the AnsibleAutomationPlatform object results in the following error in the logs of the gateway operator:

```
FAILED! => {\r\n    \"msg\": \"An unhandled exception occurred while running the lookup plugin 'template'. Error was a <class 'AttributeError'>, original message: 'list' object has no attribute 'splitlines'\"\
```

This is because the indent filter expects a string and the CRD establishes that `spec.event_stream.topology_spread_constraints` to be an array of objects. Adding `to_nice_yaml` solves the problem.