### PR TITLE
Add the ability to migrate from ClusterA to ClusterB

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2829,6 +2829,18 @@ spec:
               idle_deployment:
                 description: Scale down deployments to put EDA into an idle state
                 type: boolean
+              old_postgres_configuration_secret:
+                description: Secret where the old database configuration can be found for data migration
+                type: string
+                maxLength: 255
+                pattern: '^[a-zA-Z0-9][-a-zA-Z0-9]{0,253}[a-zA-Z0-9]$'
+              pg_dump_suffix:
+                description: Additional parameters for the pg_dump command during a migration
+                type: string
+              postgres_label_selector:
+                description: Label selector used to identify postgres pod for data migration
+                type: string
+
           status:
             description: Status defines the observed state of EDA
             properties:
@@ -2846,6 +2858,9 @@ spec:
                 type: string
               upgradedPostgresVersion:
                 description: Status to indicate that the database has been upgraded to the version in the status
+                type: string
+              migratedFromSecret:
+                description: The secret used for migrating an old instance
                 type: string
               image:
                 description: URL of the image used for the deployed instance

--- a/docs/migration/migration.md
+++ b/docs/migration/migration.md
@@ -1,0 +1,92 @@
+# Migrating data from an old EDA instance
+
+To migrate data from an older EDA installation, you must provide some information via Secrets.
+
+## Creating Secrets for Migration
+
+### DB Fields Encryption Secret
+
+You can find your old DB fields encryption key in the inventory file you used to deploy EDA in previous releases.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <resourcename>-db-fields-encryption-secret
+  namespace: <target-namespace>
+stringData:
+  db_fields_encryption: <old-encryption-key>
+type: Opaque
+```
+
+!!! note
+    `<resourcename>` must match the `name` of the EDA object you are creating. In our example below, it is `eda`.
+
+### Old Database Credentials
+
+The secret should be formatted as follows:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <resourcename>-old-postgres-configuration
+  namespace: <target namespace>
+stringData:
+  host: <external ip or url resolvable by the cluster>
+  port: "<external port, this usually defaults to 5432>"    # quotes are required
+  database: <desired database name>
+  username: <username to connect as>
+  password: <password to connect with>
+type: Opaque
+```
+
+!!! note
+    For `host`, a URL resolvable by the cluster could look something like `postgresql.<namespace>.svc.<cluster domain>`, where `<namespace>` is filled in with the namespace of the EDA deployment you are migrating data from, and `<cluster domain>` is filled in with the internal kubernetes cluster domain (In most cases it's `cluster.local`).
+
+If your EDA deployment is already using an external database server or its database is otherwise not managed by the EDA deployment, you can instead create the same secret as above but omit the `-old-` from the `name`.
+In the next section pass it in through `postgres_configuration_secret` instead, omitting the `_old_` from the key and ensuring the value matches the name of the secret. This will make EDA pick up on the existing database and apply any pending migrations.
+It is strongly recommended to backup your database beforehand.
+
+The postgresql pod for the old deployment is used when streaming data to the new postgresql pod. If your postgresql pod has a custom label, you can pass that via the `postgres_label_selector` variable to make sure the postgresql pod can be found.
+
+## Deploy EDA
+
+When you apply your EDA object, you must specify the name to the database secret you created above:
+
+```yaml
+apiVersion: eda.ansible.com/v1alpha1
+kind: EDA
+metadata:
+  name: eda
+spec:
+  old_postgres_configuration_secret: <resourcename>-old-postgres-configuration
+  db_fields_encryption_secret: <resourcename>-db-fields-encryption-secret
+  ...
+```
+
+### Exclude PostgreSQL tables during migration (optional)
+
+Use the `pg_dump_suffix` parameter under `EDA.spec` to customize the pg_dump command that will execute during migration. This variable will append your provided pg_dump parameters to the end of the 'standard' command. For example, to exclude the data from specific tables to decrease the size of the backup use:
+
+```
+pg_dump_suffix: "--exclude-table-data 'table_name*' --exclude-table-data 'another_table'"
+```
+
+## Important Note
+
+If you intend to put all the above in one file, make sure to separate each block with three dashes like so:
+
+```yaml
+---
+# Secret key
+
+---
+# Database creds
+
+---
+# EDA Config
+```
+
+Failing to do so will lead to an inoperable setup.

--- a/docs/migration/migration.md
+++ b/docs/migration/migration.md
@@ -74,6 +74,10 @@ Use the `pg_dump_suffix` parameter under `EDA.spec` to customize the pg_dump com
 pg_dump_suffix: "--exclude-table-data 'table_name*' --exclude-table-data 'another_table'"
 ```
 
+### Automatic Cleanup
+
+After a successful migration, the operator will automatically remove the `old_postgres_configuration_secret` reference from the EDA CR. This helps keep your CR clean and avoids keeping unnecessary references to resources that are no longer needed.
+
 ## Important Note
 
 If you intend to put all the above in one file, make sure to separate each block with three dashes like so:

--- a/roles/eda/tasks/cleanup_migration_references.yml
+++ b/roles/eda/tasks/cleanup_migration_references.yml
@@ -1,0 +1,25 @@
+---
+# This task file removes the old_postgres_configuration_secret reference from the EDA CR
+# after a successful migration to avoid keeping unnecessary references
+
+- name: Get current EDA CR
+  kubernetes.core.k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: eda_cr
+
+- name: Remove old_postgres_configuration_secret from EDA CR
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: "{{ api_version }}"
+      kind: "{{ kind }}"
+      metadata:
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      spec: "{{ eda_cr.resources[0].spec | combine({'old_postgres_configuration_secret': null}) }}"
+  when:
+    - eda_cr.resources | length > 0
+    - eda_cr.resources[0].spec.old_postgres_configuration_secret is defined

--- a/roles/eda/tasks/main.yml
+++ b/roles/eda/tasks/main.yml
@@ -16,9 +16,24 @@
   include_role:
     name: redis
 
+- name: Check for old postgres configuration
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ old_postgres_configuration_secret }}'
+  register: old_pg_config
+  no_log: "{{ no_log }}"
+  when: old_postgres_configuration_secret is defined
+
 - name: Setup PostgreSQL Database
   include_role:
     name: postgres
+
+- name: Migrate data from old database
+  include_tasks: migrate_data.yml
+  when:
+    - old_pg_config is defined
+    - old_pg_config['resources'] | default([]) | length > 0
 
 - name: Set EDA app images
   include_tasks: set_images.yml

--- a/roles/eda/tasks/main.yml
+++ b/roles/eda/tasks/main.yml
@@ -34,6 +34,14 @@
   when:
     - old_pg_config is defined
     - old_pg_config['resources'] | default([]) | length > 0
+  register: migration_result
+
+- name: Cleanup migration references
+  include_tasks: cleanup_migration_references.yml
+  when:
+    - migration_result is defined
+    - migration_result is success
+    - eda_migrated_from_secret is defined
 
 - name: Set EDA app images
   include_tasks: set_images.yml

--- a/roles/eda/tasks/migrate_data.yml
+++ b/roles/eda/tasks/migrate_data.yml
@@ -1,0 +1,91 @@
+---
+
+- name: Set actual old postgres configuration secret name
+  set_fact:
+    old_postgres_configuration_name: "{{ old_pg_config['resources'][0]['metadata']['name'] }}"
+
+- name: Store Database Configuration
+  set_fact:
+    eda_old_postgres_user: "{{ old_pg_config['resources'][0]['data']['username'] | b64decode }}"
+    eda_old_postgres_pass: "{{ old_pg_config['resources'][0]['data']['password'] | b64decode }}"
+    eda_old_postgres_database: "{{ old_pg_config['resources'][0]['data']['database'] | b64decode }}"
+    eda_old_postgres_port: "{{ old_pg_config['resources'][0]['data']['port'] | b64decode }}"
+    eda_old_postgres_host: "{{ old_pg_config['resources'][0]['data']['host'] | b64decode }}"
+  no_log: "{{ no_log }}"
+
+- name: Set Default label selector for custom resource generated postgres
+  set_fact:
+    postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}"
+  when: postgres_label_selector is not defined
+
+- name: Get the postgres pod information
+  k8s_info:
+    kind: Pod
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    label_selectors:
+      - "{{ postgres_label_selector }}"
+    field_selectors:
+      - status.phase=Running
+  register: postgres_pod
+
+- name: Set the resource pod name as a variable.
+  set_fact:
+    postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+
+- name: Scale down Deployment for migration
+  include_tasks: idle_deployment.yml
+
+- name: Set pg_dump command
+  set_fact:
+    pgdump: >-
+      pg_dump
+      -h {{ eda_old_postgres_host }}
+      -U {{ eda_old_postgres_user }}
+      -d {{ eda_old_postgres_database }}
+      -p {{ eda_old_postgres_port }}
+      -F custom
+      {{ pg_dump_suffix }}
+  no_log: "{{ no_log }}"
+
+- name: Set pg_restore command
+  set_fact:
+    pg_restore: >-
+      pg_restore --clean --if-exists
+      -U {{ database_username }}
+      -d {{ database_name }}
+  no_log: "{{ no_log }}"
+
+- name: Stream backup from pg_dump to the new postgresql container
+  k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod_name }}"
+    command: |
+      bash -c "
+      function end_keepalive {
+        rc=$?
+        rm -f \"$1\"
+        kill $(cat /proc/$2/task/$2/children 2>/dev/null) 2>/dev/null || true
+        wait $2 || true
+        exit $rc
+      }
+      keepalive_file=\"$(mktemp)\"
+      while [[ -f \"$keepalive_file\" ]]; do
+        echo 'Migrating data from old database...'
+        sleep 60
+      done &
+      keepalive_pid=$!
+      trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
+      echo keepalive_pid: $keepalive_pid
+      set -e -o pipefail
+      psql -c 'GRANT postgres TO {{ eda_postgres_user }}'
+      PGPASSWORD=\"$PGPASSWORD_OLD\" {{ pgdump }} | PGPASSWORD=\"$POSTGRES_PASSWORD\" {{ pg_restore }}
+      psql -c 'REVOKE postgres FROM {{ eda_postgres_user }}'
+      set +e +o pipefail
+      echo 'Successful'
+      "
+  no_log: "{{ no_log }}"
+  register: data_migration
+
+- name: Set flag signifying that this instance has been migrated
+  set_fact:
+    eda_migrated_from_secret: "{{ old_postgres_configuration_name }}"

--- a/roles/eda/tasks/update_status.yml
+++ b/roles/eda/tasks/update_status.yml
@@ -63,3 +63,13 @@
     status:
       upgradedPostgresVersion: "{{ upgraded_postgres_version | string }}"
   when: upgraded_postgres_version is defined
+
+- name: Update migratedFromSecret status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    status:
+      migratedFromSecret: "{{ eda_migrated_from_secret }}"
+  when: eda_migrated_from_secret is defined


### PR DESCRIPTION
This new logic (roles/eda/tasks/migrate_data.yml) adds the ability to migrate the database of an EDA deployment from one cluster to another. 

### EDA Migration Steps: Cluster A to Cluster B
1. Prepare Source Database Information:
  * Create a secret with your old DB fields encryption key
  * Create a secret with your old PostgreSQL connection details
2. Deploy EDA on New Cluster:
  * Create EDA CR referencing both secrets in the spec
3. Migration Process:
  * The operator automatically handles data migration
  * Streams data from old to new PostgreSQL instance
  * Runs database migrations as needed
4. Post-Migration:
  * Operator automatically removes old database reference
  * New EDA instance becomes operational with migrated data

Note: This only migrates the database and any configuration that you have on your EDA CR.  It is necessary to recreate any k8s secrets used by the EDA CR in the new namespace on clusterB.

This same procedure could be used to migrate from one namespace to another on the same cluster.