### PR TITLE
Add status.conditions.ansibleResult to the CRD and CSV to fix unknown status warning

### DIFF
--- a/config/crd/bases/eda.ansible.com_edabackups.yaml
+++ b/config/crd/bases/eda.ansible.com_edabackups.yaml
@@ -113,6 +113,9 @@ spec:
                       type: string
                     type:
                       type: string
+                    ansibleResult:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               backupDirectory:

--- a/config/crd/bases/eda.ansible.com_edarestores.yaml
+++ b/config/crd/bases/eda.ansible.com_edarestores.yaml
@@ -120,6 +120,9 @@ spec:
                       type: string
                     type:
                       type: string
+                    ansibleResult:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               restoreComplete:

--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2883,6 +2883,9 @@ spec:
                       type: string
                     type:
                       type: string
+                    ansibleResult:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
             type: object

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -102,6 +102,25 @@ spec:
         path: backupDirectory
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The resulting conditions when a Service Telemetry is instantiated
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+        properties:
+          lastTransitionTime:
+            type: string
+          reason:
+            type: string
+          status:
+            type: string
+          type:
+            type: string
+          ansibleResult:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
       version: v1alpha1
     - description: Restore a previous eda deployment from an EDABackup. The deployment
         name you provide will be the name of the new EDA CR that will be created.
@@ -186,6 +205,25 @@ spec:
         path: restoreComplete
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The resulting conditions when a Service Telemetry is instantiated
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+        properties:
+          lastTransitionTime:
+            type: string
+          reason:
+            type: string
+          status:
+            type: string
+          type:
+            type: string
+          ansibleResult:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
       version: v1alpha1
     - description: Deploy a new instance of Event-Driven Ansible Server. A standardized
         way to configure and run rulebooks to trigger automation.
@@ -769,6 +807,25 @@ spec:
         path: URL
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
+      - description: The resulting conditions when a Service Telemetry is instantiated
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+        properties:
+          lastTransitionTime:
+            type: string
+          reason:
+            type: string
+          status:
+            type: string
+          type:
+            type: string
+          ansibleResult:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
       version: v1alpha1
   description: |
     An ansible operator for managing the lifecycle of an Event-Driven Ansible


### PR DESCRIPTION
Without this change, the status condition is unknown and this warning is found in the operator logs:

```
  {"level":"info","ts":1747091990.8347256,"logger":"KubeAPIWarningLogger","msg":"unknown field status.conditions[1].ansibleResult}
```

We should do this in all of the operators. 