### PR TITLE
Fix jquery version in redirect page

### DIFF
--- a/roles/eda/templates/redirect-page.configmap.html.j2
+++ b/roles/eda/templates/redirect-page.configmap.html.j2
@@ -71,7 +71,7 @@ data:
         </p>
 
         <!-- Include any additional scripts if needed -->
-        <script src="/api/eda/static/rest_framework/js/jquery-3.5.1.min.js"></script>
+        <script src="/api/eda/static/rest_framework/js/jquery-3.7.1.min.js"></script>
         <script src="/api/eda/static/rest_framework/js/bootstrap.min.js"></script>
     </body>
     </html>


### PR DESCRIPTION
Other installer uses 3.7.1 and the file on disk is also using 3.7.1 from the rest framework directory.