### PR TITLE
Update collections to match other operators and use kubernetes.core 3.2.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: operator_sdk.util
-    version: "0.4.0"
+    version: "0.5.0"
   - name: kubernetes.core
-    version: "2.4.2"
+    version: "3.2.0"
   - name: cloud.common
-    version: "2.1.1"
+    version: "3.0.0"


### PR DESCRIPTION
SUMMARY
We are now able to update to kubernetes.core 3.2.0.

ISSUE TYPE
New or Enhanced Feature