### PR TITLE
Make the down.sh script exclude cleaning up CRDs by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,11 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 	cd config/default && $(KUSTOMIZE) edit set namespace ${NAMESPACE}
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
+.PHONY: undeploy-keep-crd
+undeploy-keep-crd: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Prevents down.sh from stomping on other CRD's in the same cluster.
+	cd config/default-keep-crd && $(KUSTOMIZE) edit set namespace ${NAMESPACE}
+	$(KUSTOMIZE) build config/default-keep-crd | kubectl delete -f -
+
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
 

--- a/config/default-keep-crd/manager_auth_proxy_patch.yaml
+++ b/config/default-keep-crd/manager_auth_proxy_patch.yaml
@@ -1,0 +1,65 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+      serviceAccountName: controller-manager
+      automountServiceAccountToken: false
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - name: eda-manager
+        args:
+        - "--health-probe-bind-address=:6789"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        - "--leader-election-id=eda-server-operator"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1500Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi

--- a/dev/eda-cr/eda-openshift-cr.yml
+++ b/dev/eda-cr/eda-openshift-cr.yml
@@ -34,7 +34,7 @@ spec:
       value: "Always"
 
   # CA Bundle
-  bundle_cacert_secret: my-custom-certs
+  # bundle_cacert_secret: my-custom-certs
 
   # -- Resource Requirements
   api:

--- a/down.sh
+++ b/down.sh
@@ -21,9 +21,23 @@ kubectl delete edarestore --all
 # Delete old operator deployment
 kubectl delete deployment eda-server-operator-controller-manager
 
+# Parse command line arguments
+ALL_FLAG=false
+for arg in "$@"; do
+  case $arg in
+    --all)
+      ALL_FLAG=true
+      shift
+      ;;
+  esac
+done
+
 # Deploy Operator
-make undeploy IMG=$IMG NAMESPACE=$NAMESPACE
+if [ "$ALL_FLAG" = true ]; then
+  make undeploy IMG=$IMG NAMESPACE=$NAMESPACE
+else
+  make undeploy-keep-crd IMG=$IMG NAMESPACE=$NAMESPACE
+fi
 
 # Remove PVCs
 kubectl delete pvc postgres-15-$EDA_CR-postgres-15-0
-


### PR DESCRIPTION
# Summary

Without this change, by default, the down.sh will delete all EDA related CRD's on the cluster.  If there are other EDA operators on the cluster or the AAP Operator is in another namespace on this cluster, this could clobber the CRD for all.  To avoid that, I am changing the default behavior so that it keeps the CRD's.  Optionally, you can pass the `--all` flag to delete them as well.

## Details

Added --all flag to  down.sh
This PR adds an optional --all flag to the  down.sh script that controls whether CRDs are removed during cleanup.

Usage:
 * ./down.sh - Default behavior, uses make undeploy-keep-crd to clean up resources while preserving CRDs
* ./down.sh --all - Enhanced cleanup, uses make undeploy to remove all resources including CRDs
This change helps developers who need a complete cleanup of their environment, while maintaining backward compatibility with the existing workflow.

```
./down.sh --all
```