### PR TITLE
Timeout before the openshift route times out

### DIFF
--- a/dev/eda-cr/eda-minimal-openshift-cr.yml
+++ b/dev/eda-cr/eda-minimal-openshift-cr.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: eda.ansible.com/v1alpha1
+kind: EDA
+metadata:
+  name: eda
+  namespace: eda-demo
+spec:
+  ingress_type: route
+  automation_server_url: awx.example.com 

--- a/eda-demo.yml
+++ b/eda-demo.yml
@@ -4,3 +4,6 @@ metadata:
   name: eda-demo
 spec:
   no_log: false
+  extra_settings:
+    - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
+      vaue: true

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -171,3 +171,9 @@ ipv6_disabled: false
 
 # idle_deployment - Scale down deployments to put EDA into an idle state
 idle_deployment: false
+
+# timeout defaults for nginx and gunicorn_workers
+client_request_timeout: 30
+eda_gunicorn_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 3) | int }}'
+eda_gunicorn_grace_period: 2
+eda_nginx_read_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 2) | int }}'

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -171,9 +171,3 @@ ipv6_disabled: false
 
 # idle_deployment - Scale down deployments to put EDA into an idle state
 idle_deployment: false
-
-# timeout defaults for nginx and gunicorn_workers
-client_request_timeout: 30
-eda_gunicorn_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 3) | int }}'
-eda_gunicorn_grace_period: 2
-eda_nginx_read_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 2) | int }}'

--- a/roles/eda/templates/eda-api.configmap.yaml.j2
+++ b/roles/eda/templates/eda-api.configmap.yaml.j2
@@ -38,6 +38,10 @@ data:
                 proxy_set_header X-Forwarded-Proto $scheme;
                 proxy_set_header X-Forwarded-Port $server_port;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                # Return 503 Service Unavailable with JSON response if gunicorn fails to respond
+                proxy_read_timeout {{ eda_nginx_read_timeout }}s;
+                error_page 504 =503 /json_503;
+                error_page 502 =503 /json_503;  # Optional, in case gunicorn is completely down    
             }
             location / {
                 root {{ static_path }};
@@ -45,5 +49,18 @@ data:
                 access_log /var/log/nginx/proxy_access.log;
                 error_log /var/log/nginx/proxy_error.log;
             }
+            location = /json_503 {
+                # Custom JSON response for 503 Service Unavailable
+                internal;
+                add_header Content-Type application/json;
+    
+                # Check if X-Request-ID is set and include it in the response
+                if ($http_x_request_id) {
+                    return 503 '{"status": "error", "message": "Service Unavailable", "code": 503, "request_id": "$http_x_request_id"}';
+                }
+    
+                # If X-Request-ID is not set, just return the basic JSON response
+                return 503 '{"status": "error", "message": "Service Unavailable", "code": 503}';
+            }    
         }
     }

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -200,7 +200,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - gunicorn --bind 0.0.0.0:{{ api_django_port }} --workers {{ combined_api.gunicorn_workers }} aap_eda.wsgi:application
+        - gunicorn --bind 0.0.0.0:{{ api_django_port }} --workers {{ combined_api.gunicorn_workers }} --timeout {{ eda_gunicorn_timeout }} --graceful-timeout {{ eda_gunicorn_timeout_grace_period }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -128,7 +128,7 @@ spec:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
         env:
         - name: ANSIBLE_REVERSE_RESOURCE_SYNC
-          value: 'true'
+          value: 'false'
         - name: EDA_ACTIVATION_DB_HOST
           valueFrom:
             secretKeyRef:
@@ -200,7 +200,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - gunicorn --bind 0.0.0.0:{{ api_django_port }} --workers {{ combined_api.gunicorn_workers }} --timeout {{ eda_gunicorn_timeout }} --graceful-timeout {{ eda_gunicorn_timeout_grace_period }} aap_eda.wsgi:application
+        - gunicorn --bind 0.0.0.0:{{ api_django_port }} --workers {{ combined_api.gunicorn_workers }} --timeout {{ gunicorn_timeout }} --graceful-timeout {{ gunicorn_timeout_grace_period }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'

--- a/roles/eda/templates/eda-event-stream.configmap.yaml.j2
+++ b/roles/eda/templates/eda-event-stream.configmap.yaml.j2
@@ -33,6 +33,23 @@ data:
                 proxy_set_header        X-Forwarded-Host $host;
                 proxy_set_header        X-Forwarded-Port $server_port;
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+                # Return 503 Service Unavailable with JSON response if gunicorn fails to respond
+                proxy_read_timeout {{ eda_nginx_read_timeout }}s;
+                error_page 504 =503 /json_503;
+                error_page 502 =503 /json_503;  # Optional, in case gunicorn is completely down    
             }
+            location = /json_503 {
+                # Custom JSON response for 503 Service Unavailable
+                internal;
+                add_header Content-Type application/json;
+    
+                # Check if X-Request-ID is set and include it in the response
+                if ($http_x_request_id) {
+                    return 503 '{"status": "error", "message": "Service Unavailable", "code": 503, "request_id": "$http_x_request_id"}';
+                }
+    
+                # If X-Request-ID is not set, just return the basic JSON response
+                return 503 '{"status": "error", "message": "Service Unavailable", "code": 503}';
+            }    
         }
     }

--- a/roles/eda/templates/eda-event-stream.deployment.yaml.j2
+++ b/roles/eda/templates/eda-event-stream.deployment.yaml.j2
@@ -142,7 +142,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - gunicorn --bind 0.0.0.0:{{ event_stream_django_port }} --workers {{ combined_event_stream.gunicorn_workers }} --timeout {{ eda_gunicorn_timeout }} --graceful-timeout {{ eda_gunicorn_timeout_grace_period }} aap_eda.wsgi:application
+        - gunicorn --bind 0.0.0.0:{{ event_stream_django_port }} --workers {{ combined_event_stream.gunicorn_workers }} --timeout {{ gunicorn_timeout }} --graceful-timeout {{ gunicorn_timeout_grace_period }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'

--- a/roles/eda/templates/eda-event-stream.deployment.yaml.j2
+++ b/roles/eda/templates/eda-event-stream.deployment.yaml.j2
@@ -142,7 +142,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - gunicorn --bind 0.0.0.0:{{ event_stream_django_port }} --workers {{ combined_event_stream.gunicorn_workers }} aap_eda.wsgi:application
+        - gunicorn --bind 0.0.0.0:{{ event_stream_django_port }} --workers {{ combined_event_stream.gunicorn_workers }} --timeout {{ eda_gunicorn_timeout }} --graceful-timeout {{ eda_gunicorn_timeout_grace_period }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -91,6 +91,10 @@ data:
                 proxy_set_header X-Forwarded-Proto $remote_scheme;
                 proxy_set_header X-Forwarded-Port $server_port;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                # Return 503 Service Unavailable with JSON response if gunicorn fails to respond
+                proxy_read_timeout {{ eda_nginx_read_timeout }}s;
+                error_page 504 =503 /json_503;
+                error_page 502 =503 /json_503;  # Optional, in case gunicorn is completely down    
             }
 
             location ~* \.(json|woff|woff2|jpe?g|png|gif|ico|svg|css|js)$ {
@@ -105,5 +109,18 @@ data:
                 add_header Cache-Control "public, max-age=0, s-maxage=0, must-revalidate" always;
                 try_files $uri $uri/ /index.html =404;
             }
+            location = /json_503 {
+              # Custom JSON response for 503 Service Unavailable
+              internal;
+              add_header Content-Type application/json;
+  
+              # Check if X-Request-ID is set and include it in the response
+              if ($http_x_request_id) {
+                  return 503 '{"status": "error", "message": "Service Unavailable", "code": 503, "request_id": "$http_x_request_id"}';
+              }
+  
+              # If X-Request-ID is not set, just return the basic JSON response
+              return 503 '{"status": "error", "message": "Service Unavailable", "code": 503}';
+          }   
         }
       }

--- a/roles/eda/vars/main.yml
+++ b/roles/eda/vars/main.yml
@@ -14,3 +14,9 @@ eda_event_stream_prefix_path: "{{ event_stream.prefix | default('/eda-event-stre
 event_stream_nginx_port: 8000
 event_stream_server_name: "{{ ansible_operator_meta.name }}-event-stream"
 event_stream_django_port: 8002
+
+# timeout defaults for nginx and gunicorn_workers
+client_request_timeout: 30
+gunicorn_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 3) | int }}'
+gunicorn_timeout_grace_period: 2
+eda_nginx_read_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 2) | int }}'


### PR DESCRIPTION
not timing out before undercuts usefulness of our log-traceback-middleware in django-ansible-base that logs a traceback from requests that get timed out -- because uwsgi or gunicorn has to send the timeout signal to the worker handling the request. Also leads to issues where requests that envoy has already timed out are filling up queues of the workers of the components.

Also, configure nginx to return a 503 if WSGI server doesn't respond.
Similar changes for the AWX operator: https://github.com/ansible/awx-operator/pull/2056