### PR TITLE
feat(eda): remove support for max_running_activations - AAP-49981

### DIFF
--- a/dev/eda-cr/eda-k8s-ing.yml
+++ b/dev/eda-cr/eda-k8s-ing.yml
@@ -25,8 +25,6 @@ spec:
 
   # -- Example extra settings
   extra_settings:
-    - setting: EDA_MAX_RUNNING_ACTIVATIONS
-      value: '11'
     - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
       value: true
     - setting: DEFAULT_PULL_POLICY

--- a/dev/eda-cr/eda-k8s-nodeport-cr.yml
+++ b/dev/eda-cr/eda-k8s-nodeport-cr.yml
@@ -25,8 +25,6 @@ spec:
 
   # -- Example extra settings
   extra_settings:
-    - setting: EDA_MAX_RUNNING_ACTIVATIONS
-      value: '11'
     - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
       value: true
     - setting: DEFAULT_PULL_POLICY

--- a/dev/eda-cr/eda-openshift-cr.yml
+++ b/dev/eda-cr/eda-openshift-cr.yml
@@ -28,8 +28,6 @@ spec:
 
   # -- Example extra settings
   extra_settings:
-    - setting: EDA_MAX_RUNNING_ACTIVATIONS
-      value: '11'
     - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
       vaue: true
     - setting: DEFAULT_PULL_POLICY

--- a/docs/user-guide/advanced-configuration/settings.md
+++ b/docs/user-guide/advanced-configuration/settings.md
@@ -12,10 +12,8 @@ metadata:
 spec:
   ...
   extra_settings:
-    - setting: EDA_MAX_RUNNING_ACTIVATIONS
-      value: "12"
-    - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      value: true
+    - setting: EDA_APP_LOG_LEVEL
+      value: "DEBUG"
 
 ```
 
@@ -27,4 +25,4 @@ Below is a table of the setting name, default value, and a description of it's p
 
 | Setting Name             | Default Value  | Description                                     |
 |--------------------------|----------------|-------------------------------------------------|
-| EDA_MAX_RUNNING_ACTIVATIONS  | "12"           | Maximum number of running activations           |
+| EDA_APP_LOG_LEVEL  | "INFO"           | Log level           |

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -29,7 +29,6 @@ data:
   EDA_WEBSOCKET_BASE_URL: "ws://{{ websocket_server_name }}:{{ websocket_port }}"
   EDA_WEBSOCKET_TOKEN_BASE_URL: "http://{{ api_server_name }}:{{ api_nginx_port }}"
   EDA_WEBSOCKET_SSL_VERIFY: "{{ websocket_ssl_verify }}"
-  EDA_MAX_RUNNING_ACTIVATIONS: "12"
 
   EDA_STATIC_URL: /api/eda/static/
 


### PR DESCRIPTION
Remove support and references for `max_running_activations` static settings. 
This setting is removed from eda-server, this PR aligns the change. 
Further information: https://github.com/ansible/eda-server/pull/1365 
Jira: https://issues.redhat.com/browse/AAP-49981