### PR TITLE
[DRAFT]  set client_request_timeout from annotation in the CR

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -20,6 +20,32 @@
 
 # tasks file for EDA
 
+# get and set annotations passed via CR
+- name: Look up details for this deployment
+  k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: this_eda
+
+- name: set annotations based on this_eda
+  set_fact:
+    this_annotations: "{{ this_eda['resources'][0]['metadata']['annotations'] | default({}) }}"
+
+- name: set client_request_timeout based on annotation
+  set_fact:
+    client_request_timeout: "{{ (this_annotations['aap.ansible.io/client-request-timeout'][:-1]) | int }}"
+    client_request_timeout_overidden: true
+  when:
+    - "'aap.ansible.io/client-request-timeout' in this_annotations"
+    - this_annotations['aap.ansible.io/client-request-timeout'] is match('^\\d+s$')
+
+- name: client_request_timeout has been changed
+  debug:
+    msg: "client_request_timeout's default 30s value has been overriden by the annotation 'aap.ansible.io/client-request-timeout' to {{ client_request_timeout }}s"
+  when: client_request_timeout_overidden | default(false)
+
 - name: Create EDA ServiceAccount
   k8s:
     apply: yes


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

add tasks to check CR for annotations and update timeout based on the passed value
These new tasks will:
- check for annotation for client_request_timeout
- if annotation is present, override default value (currently set to 30s)
- log message noting the change

follow up PR of: https://github.com/ansible/eda-server-operator/pull/294

matching PRS for other operators: 
- https://github.com/ansible/awx-operator/pull/2077
- https://github.com/ansible/galaxy-operator/pull/213