### PR TITLE
feat: [AAP-54950] Add IPv6 support

### DIFF
--- a/dev/eda-cr/eda-openshift-cr.yml
+++ b/dev/eda-cr/eda-openshift-cr.yml
@@ -29,7 +29,7 @@ spec:
   # -- Example extra settings
   extra_settings:
     - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      vaue: true
+      value: true
     - setting: DEFAULT_PULL_POLICY
       value: "Always"
 

--- a/dev/eda-cr/eda-resource-quota-cr.yml
+++ b/dev/eda-cr/eda-resource-quota-cr.yml
@@ -11,7 +11,7 @@ spec:
   image_pull_policy: Always
   extra_settings:
     - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      vaue: true
+      value: true
 
   api:
     replicas: 1

--- a/dev/eda-cr/lightweight-eda.yml
+++ b/dev/eda-cr/lightweight-eda.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   extra_settings:
     - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      vaue: true
+      value: true
     - setting: GIT_SSL_NO_VERIFY
       value: "true"
 

--- a/eda-demo.yml
+++ b/eda-demo.yml
@@ -6,4 +6,4 @@ spec:
   no_log: false
   extra_settings:
     - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      vaue: true
+      value: true

--- a/roles/eda/templates/eda-api.configmap.yaml.j2
+++ b/roles/eda/templates/eda-api.configmap.yaml.j2
@@ -26,6 +26,9 @@ data:
 
         server {
             listen {{ api_nginx_port }};
+            {% if not ipv6_disabled | bool %}
+            listen [::]:{{ api_nginx_port }};
+            {% endif %}
             location ^~ /api/eda/static/ {
                 alias {{ static_path }}/;
                 access_log /var/log/nginx/static_access.log;

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -200,7 +200,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - gunicorn --bind 0.0.0.0:{{ api_django_port }} --workers {{ combined_api.gunicorn_workers }} --timeout {{ gunicorn_timeout }} --graceful-timeout {{ gunicorn_timeout_grace_period }} aap_eda.wsgi:application
+        - gunicorn --bind '{{ api_bind_address }}:{{ api_django_port }}' --workers {{ combined_api.gunicorn_workers }} --timeout {{ gunicorn_timeout }} --graceful-timeout {{ gunicorn_timeout_grace_period }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
@@ -302,7 +302,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - daphne -b 0.0.0.0 -p {{ websocket_port }} aap_eda.asgi:application
+        - daphne -b '{{ api_bind_address }}' -p {{ websocket_port }} aap_eda.asgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'

--- a/roles/eda/templates/eda-event-stream.deployment.yaml.j2
+++ b/roles/eda/templates/eda-event-stream.deployment.yaml.j2
@@ -142,7 +142,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - gunicorn --bind 0.0.0.0:{{ event_stream_django_port }} --workers {{ combined_event_stream.gunicorn_workers }} --timeout {{ gunicorn_timeout }} --graceful-timeout {{ gunicorn_timeout_grace_period }} aap_eda.wsgi:application
+        - gunicorn --bind '{{ api_bind_address }}:{{ event_stream_django_port }}' --workers {{ combined_event_stream.gunicorn_workers }} --timeout {{ gunicorn_timeout }} --graceful-timeout {{ gunicorn_timeout_grace_period }} aap_eda.wsgi:application
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'

--- a/roles/eda/vars/main.yml
+++ b/roles/eda/vars/main.yml
@@ -20,3 +20,6 @@ client_request_timeout: 30
 gunicorn_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 3) | int }}'
 gunicorn_timeout_grace_period: 2
 eda_nginx_read_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 2) | int }}'
+
+# Define which address to bind in the api, depending on the enabled IP version
+api_bind_address: "{{ (ipv6_disabled | bool) | ternary('0.0.0.0', '[::]') }}"


### PR DESCRIPTION
The changes in the deployment allow for gunicorn and daphne to bind to `::` instead. As IPv6 FE80 Link-Local is always present, this won't fail. If the pod has a proper IPv6 address in its interface, this still works, essentially allowing for seamlessly bind to IPv4 and IPv6 (dual-stack) addresses, while also enabling the operator to run in single-stack IPv6 scenarios.

We do the same for the configmap that defines the nginx configuration. Given it already listens to IPv4, we make it listen to IPv6 wildcard as well, unless explicitly disabled via the `ipv6_disabled` variable.

This also fixes a few typos in some dev/demo EDA CR definitions.