### PR TITLE
[AAP-63048] EDA: Update worker commands from rqworker to dispatcherd

### DIFF
--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -142,7 +142,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - aap-eda-manage rqworker --worker-class aap_eda.core.tasking.ActivationWorker
+        - aap-eda-manage dispatcherd --worker-class ActivationWorker
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -142,7 +142,7 @@ spec:
         args:
         - /bin/bash
         - -c
-        - aap-eda-manage rqworker --worker-class aap_eda.core.tasking.DefaultWorker
+        - aap-eda-manage dispatcherd --worker-class DefaultWorker
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-63048

Change EDA worker and activation worker containers to use `aap-eda-manage dispatcherd` instead of `rqworker'`and update worker class format from fully qualified to simple class names.