### PR TITLE
feat: [AAP-59027,AAP-59028] cleanup old redis artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ spec:
 - [Deploy a Specific Version of EDA](./docs/user-guide/advanced-configuration/deploying-a-specific-version.md)
 - [Trusting a Custom Certificate Authority](./docs/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.md)
 - [Database Configuration](./docs/user-guide/database-configuration.md)
+- [Redis Removal Notice](./docs/user-guide/redis-configuration.md)
 
 ## Maintainers Docs
 

--- a/docs/upgrade/upgrading.md
+++ b/docs/upgrade/upgrading.md
@@ -48,6 +48,23 @@ In the event you need to recover the backup see the [restore role documentation]
 **Note**: Do not delete the namespace/project, as that will delete the backup and the backup's PVC as well.
 
 
+#### Redis Removal
+
+Starting with this version, the EDA operator **no longer deploys or supports Redis**. EDA now uses [dispatcherd](https://github.com/ansible/dispatcherd), a PostgreSQL `pg_notify`-based task queuing system that eliminates the need for a separate Redis instance.
+
+**What happens automatically during the upgrade:**
+
+- The operator deletes any existing managed Redis Deployment (`<name>-redis`), Service (`<name>-redis-svc`), and Secret (`<name>-redis-configuration`).
+- No data migration is required — Redis was used only for transient message queuing (`emptyDir` storage), and all durable task state is persisted in PostgreSQL.
+
+**What you need to do:**
+
+- **Remove the `redis` section from your EDA CR spec when convenient.** If your CR still contains a `redis` section, the operator will log a deprecation warning and ignore it — the upgrade will proceed normally. You should remove the `redis:` block at your earliest convenience.
+- **Decommission any external Redis instance** that was dedicated to EDA. No EDA component connects to Redis anymore.
+- The `redis_image` and `redis_image_version` CR fields have also been removed.
+
+For more details, see the [Redis Removal Notice](../user-guide/redis-configuration.md).
+
 #### PostgreSQL Upgrade Considerations
 
 If there is a PostgreSQL major version upgrade, after the data directory on the PVC is migrated to the new version, the old PVC is kept by default.

--- a/docs/user-guide/advanced-configuration/assigning-eda-pods-to-specific-nodes.md
+++ b/docs/user-guide/advanced-configuration/assigning-eda-pods-to-specific-nodes.md
@@ -2,7 +2,7 @@
 
 You can constrain the EDA pods created by the operator to run on a certain subset of nodes. `node_selector` and `tolerations` contrain the EDA pods to run only on the nodes that match the specified key/value pairs. 
 
-Each component of EDA has its own `node_selector` and `tolerations` values. The supported components are `ui`, `api`, `default_worker`, `activation_worker`, `worker`, `redis` and `database`.
+Each component of EDA has its own `node_selector` and `tolerations` values. The supported components are `ui`, `api`, `default_worker`, `activation_worker`, `worker` and `database`.
 
 | Name | Description | Type | Default |
 |---|---|---|---|

--- a/docs/user-guide/advanced-configuration/deploying-a-specific-version.md
+++ b/docs/user-guide/advanced-configuration/deploying-a-specific-version.md
@@ -10,8 +10,6 @@ There are a few variables that are customizable for eda the image management.
 | image_web_version      | Image version to pull     | value of DEFAULT_EDA_UI_VERSION or main |
 | image_pull_policy      | The pull policy to adopt  | IfNotPresent                            |
 | image_pull_secrets     | The pull secrets to use   | None                                    |
-| redis_image            | Path of the image to pull | redis                                   |
-| redis_image_version    | Image version to pull     | c9s                                     |
 | postgres_image         | Path of the image to pull | postgres                                |
 | postgres_image_version | Image version to pull     | latest                                  |
 

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -94,6 +94,30 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     state: absent
 
+- name: Remove legacy Redis deployment
+  k8s:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}-redis"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+
+- name: Remove legacy Redis service
+  k8s:
+    api_version: v1
+    kind: Service
+    name: "{{ ansible_operator_meta.name }}-redis-svc"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+
+- name: Remove legacy Redis secret
+  k8s:
+    api_version: v1
+    kind: Secret
+    name: "{{ ansible_operator_meta.name }}-redis-configuration"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+
 - name: Check for API Pod
   k8s_info:
     kind: Pod

--- a/roles/eda/tasks/main.yml
+++ b/roles/eda/tasks/main.yml
@@ -4,6 +4,21 @@
 - name: Combine default and custom vars for each component
   include_tasks: combine_defaults.yml
 
+- name: Warn if user still references redis configuration
+  ansible.builtin.debug:
+    msg: >-
+      [DEPRECATION WARNING] Redis configuration detected in the EDA custom
+      resource spec but Redis is no longer used by EDA. The 'redis' section
+      (including 'redis.redis_secret') will be ignored. EDA now uses
+      dispatcherd (backed by PostgreSQL) for task queuing. Please remove
+      the 'redis' section from your EDA custom resource spec at your
+      earliest convenience. No data migration from Redis is required as
+      task state is persisted in PostgreSQL.
+  when:
+    - redis is defined
+    - redis is mapping
+    - redis | length > 0
+
 - name: Configure cluster
   include_role:
     name: common


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-59028
https://issues.redhat.com/browse/AAP-59027

Also, we add a fail-fast task that makes impossible for
a user to silently run a misconfigured state, thinking redis
is backing EDA.

We then make explicit to the user what needs to be changed.
Documentation update will be treated in a future change.