### PR TITLE
fix: gate RESOURCE_SERVER and local resource management on gateway presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ stringData:
 
 ### Allow Local Resource Management
 
-Resources such as users, teams, or organizations are recommended to be managed by the *Platform Provider*. Flag `EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT` can be toggled to instruct whether EDA can create/modify/delete these resources. The following example allows EDA to manage such resources. It is necessary when EDA is deployed alone.
+Resources such as users, teams, or organizations are recommended to be managed by the *Platform Provider*. When EDA is deployed standalone (without `public_base_url`), the operator automatically sets `EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT` to `True` and clears `EDA_RESOURCE_SERVER__URL`, enabling local user/team/organization management and session-based login.
+
+If you need to override this behavior in a standalone deployment, use `extra_settings`:
 
 ```yaml
 apiVersion: eda.ansible.com/v1alpha1
@@ -197,7 +199,7 @@ metadata:
 spec:
   extra_settings:
     - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      value: true
+      value: false
 ```
 
 ### Database Fields Encryption Configuration

--- a/dev/eda-cr/eda-k8s-ing.yml
+++ b/dev/eda-cr/eda-k8s-ing.yml
@@ -25,8 +25,6 @@ spec:
 
   # -- Example extra settings
   extra_settings:
-    - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      value: true
     - setting: DEFAULT_PULL_POLICY
       value: "Always"
 

--- a/dev/eda-cr/eda-k8s-nodeport-cr.yml
+++ b/dev/eda-cr/eda-k8s-nodeport-cr.yml
@@ -25,8 +25,6 @@ spec:
 
   # -- Example extra settings
   extra_settings:
-    - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      value: true
     - setting: DEFAULT_PULL_POLICY
       value: "Always"
 

--- a/dev/eda-cr/eda-openshift-cr.yml
+++ b/dev/eda-cr/eda-openshift-cr.yml
@@ -28,8 +28,6 @@ spec:
 
   # -- Example extra settings
   extra_settings:
-    - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      value: true
     - setting: DEFAULT_PULL_POLICY
       value: "Always"
 

--- a/dev/eda-cr/eda-resource-quota-cr.yml
+++ b/dev/eda-cr/eda-resource-quota-cr.yml
@@ -9,10 +9,6 @@ spec:
   ingress_type: Route
   no_log: false
   image_pull_policy: Always
-  extra_settings:
-    - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      value: true
-
   api:
     replicas: 1
     resource_requirements:

--- a/dev/eda-cr/lightweight-eda.yml
+++ b/dev/eda-cr/lightweight-eda.yml
@@ -5,8 +5,6 @@ metadata:
   name: eda
 spec:
   extra_settings:
-    - setting: EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT
-      value: true
     - setting: GIT_SSL_NO_VERIFY
       value: "true"
 

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -35,9 +35,14 @@ data:
   EDA_STATIC_URL: /api/eda/static/
 
   # Resource Server configuration
-{% if not (public_base_url | default('') | length > 0) %}
+{% set _user_settings = (extra_settings | default([])) | map(attribute='setting') | map('upper') | list %}
+{% if public_base_url | default('') | length == 0 %}
+{% if 'EDA_RESOURCE_SERVER__URL' not in _user_settings %}
   EDA_RESOURCE_SERVER__URL: ""
+{% endif %}
+{% if 'EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT' not in _user_settings %}
   EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT: "True"
+{% endif %}
 {% endif %}
 
   # Custom user variables

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -34,6 +34,12 @@ data:
 
   EDA_STATIC_URL: /api/eda/static/
 
+  # Resource Server configuration
+{% if not (public_base_url | default('') | length > 0) %}
+  EDA_RESOURCE_SERVER__URL: ""
+  EDA_ALLOW_LOCAL_RESOURCE_MANAGEMENT: "True"
+{% endif %}
+
   # Custom user variables
 {% for item in extra_settings | default([]) %}
   {{ item.setting | upper }}: "{{ item.value }}"


### PR DESCRIPTION
EDA server defaults `RESOURCE_SERVER__URL` to `"https://localhost"`, which causes `apply_resource_server_auth` to unconditionally restrict authentication to JWT-only, breaking session-based login for standalone deployments. This was introduced by the gateway-only auth enforcing, whenever `RESOURCE_SERVER__URL` is truthy. Development mode is unaffected because development_defaults.py sets it to None [3].

We now use `public_base_url` (the same mechanism other operators use) to detect gateway presence and explicitly configure standalone deployments in the ConfigMap. It should unblock access to the UI when deploying the EDA operator in standalone mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added automatic local resource management when no public base URL is configured.
* Resource server settings are now applied conditionally based on the configured public base URL.

## Documentation
* Updated standalone deployment guidance to reflect the automatic configuration behavior.

## Configuration
* Simplified deployment examples by removing redundant local resource management settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->