### PR TITLE
feat: add support for event persistence

### DIFF
--- a/.ci/eda_v1alpha1_eda.event_persistence.ci.yaml
+++ b/.ci/eda_v1alpha1_eda.event_persistence.ci.yaml
@@ -1,0 +1,11 @@
+apiVersion: eda.ansible.com/v1alpha1
+kind: EDA
+metadata:
+  name: eda-demo
+  annotations:
+    "ansible.sdk.operatorframework.io/verbosity": "5"
+spec:
+  no_log: false
+  automation_server_url: http://foo.bar
+  event_persistence:
+    deploy_db: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - SCENARIO: default  # tests headless scenario too
           - SCENARIO: externaldb
           - SCENARIO: ingress
+          - SCENARIO: event_persistence
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,7 @@ jobs:
           - SCENARIO: default
           - SCENARIO: externaldb
           - SCENARIO: ingress
+          - SCENARIO: event_persistence
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -441,6 +441,27 @@ spec:
                       type: object
                     type: array
                 type: object
+              event_persistence:
+                description: |
+                  Defines desired state of Event Persistence database.
+                  Event persistence is opt-in. Set deploy_db: true to provision a dedicated
+                  database for persisting in-flight events during activation processing.
+                properties:
+                  deploy_db:
+                    description: |
+                      Deploy the event persistence database.
+                      When true, the operator will create a dedicated database and auto-generate
+                      credentials for event persistence. When false or omitted, event persistence
+                      is not configured automatically in EDA.
+                    type: boolean
+                    default: false
+                  database_secret:
+                    description: |
+                      Name of a pre-existing secret containing event persistence database credentials.
+                      This is primarily used internally when deployed via the AAP gateway operator.
+                      If not provided, credentials will be auto-generated for managed databases.
+                    type: string
+                type: object
               event_stream:
                 description: Defines desired state of Event Stream resources
                 properties:

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -178,3 +178,30 @@ spec:
 ```
 
 **Note**: The variable `sslmode` is valid for `external` databases only. The allowed values are: `prefer`, `disable`, `allow`, `require`, `verify-ca`, `verify-full`.
+
+#### Event Persistence Database
+
+The EDA operator supports provisioning a dedicated PostgreSQL database (`eda_event_persistence`) for event persistence. This database stores in-flight events during activation processing to prevent event loss during planned or unplanned downtime.
+
+Unlike the event stream database user (which shares the main EDA database), the event persistence feature requires a **separate database** with its own user.
+
+**Event persistence is opt-in.** The database is only provisioned when you explicitly set `event_persistence.deploy_db: true` in your EDA CR. When not enabled, the `EDA_EVENT_PERSISTENCE_DB_*` environment variables are not set, and the event persistence feature remains disabled in EDA.
+
+To enable event persistence:
+
+```yaml
+---
+spec:
+  ...
+  event_persistence:
+    deploy_db: true
+```
+
+The operator will automatically:
+
+1. Generate credentials and store them in a secret named `<instance-name>-event-persistence-postgres-configuration`
+2. Create the `eda_event_persistence` user on the managed PostgreSQL instance
+3. Create the `eda_event_persistence` database owned by that user
+4. Inject the credentials into the API and activation worker deployments
+
+**Note**: For external database deployments, event persistence database credentials are not managed by the operator. Users with external databases can configure event persistence by creating a Rule Engine credential directly in EDA with their external database details.

--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -13,6 +13,12 @@
     - eventStreamDatabaseConfigurationSecret
   when: this_eda['resources'][0]['status']['eventStreamDatabaseConfigurationSecret'] | default('') | length > 0
 
+- name: Dump event persistence database secret if present
+  include_tasks: dump_generated_secret.yml
+  with_items:
+    - eventPersistenceDatabaseConfigurationSecret
+  when: this_eda['resources'][0]['status']['eventPersistenceDatabaseConfigurationSecret'] | default('') | length > 0
+
 - name: Dump secret names from eda spec and data into file
   include_tasks: dump_secret.yml
   loop:

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -165,6 +165,10 @@ event_stream_prefix_path: "{{ event_stream.prefix | default('/eda-event-streams'
 event_stream_database_username: eda_event_stream
 event_stream_pg_sslmode: "prefer"
 
+# Event persistence database configuration
+event_persistence: {}
+event_persistence_pg_sslmode: "prefer"
+
 # Disable UI container's nginx ipv6 listener
 ipv6_disabled: false
 

--- a/roles/eda/tasks/update_status.yml
+++ b/roles/eda/tasks/update_status.yml
@@ -22,6 +22,16 @@
       eventStreamDatabaseConfigurationSecret: "{{ __event_stream_database_secret }}"
   when: __event_stream_database_secret is defined
 
+- name: Update event persistence database secret status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    status:
+      eventPersistenceDatabaseConfigurationSecret: "{{ __event_persistence_database_secret }}"
+  when: __event_persistence_database_secret is defined
+
 - block:
     - name: Retrieve instance version
       k8s_exec:

--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -111,6 +111,36 @@ spec:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
+{% if __event_persistence_database_secret is defined %}
+        # Event persistence database credentials
+        - name: EDA_EVENT_PERSISTENCE_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: host
+        - name: EDA_EVENT_PERSISTENCE_DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: port
+        - name: EDA_EVENT_PERSISTENCE_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: database
+        - name: EDA_EVENT_PERSISTENCE_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: username
+        - name: EDA_EVENT_PERSISTENCE_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: password
+        - name: EDA_EVENT_PERSISTENCE_PGSSLMODE
+          value: '{{ event_persistence_postgres_sslmode }}'
+{% endif %}
 {% if combined_activation_worker.resource_requirements is defined %}
         resources: {{ combined_activation_worker.resource_requirements }}
 {% endif %}
@@ -182,6 +212,36 @@ spec:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
+{% if __event_persistence_database_secret is defined %}
+        # Event persistence database credentials
+        - name: EDA_EVENT_PERSISTENCE_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: host
+        - name: EDA_EVENT_PERSISTENCE_DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: port
+        - name: EDA_EVENT_PERSISTENCE_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: database
+        - name: EDA_EVENT_PERSISTENCE_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: username
+        - name: EDA_EVENT_PERSISTENCE_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: password
+        - name: EDA_EVENT_PERSISTENCE_PGSSLMODE
+          value: '{{ event_persistence_postgres_sslmode }}'
+{% endif %}
 {% if combined_activation_worker.resource_requirements is defined %}
         resources: {{ combined_activation_worker.resource_requirements }}
 {% endif %}

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -52,6 +52,9 @@ spec:
 {% if event_stream_pg_config is defined %}
         checksum-secret-event-stream-db: "{{ event_stream_pg_config['resources'][0]['data'] | default('') | sha1 }}"
 {% endif %}
+{% if event_persistence_pg_config is defined %}
+        checksum-secret-event-persistence-db: "{{ event_persistence_pg_config['resources'][0]['data'] | default('') | sha1 }}"
+{% endif %}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secrets | length > 0 %}
@@ -182,6 +185,36 @@ spec:
         - name: EDA_EVENT_STREAM_DB_SSLMODE
           value: '{{ event_stream_postgres_sslmode }}'
 {% endif %}
+{% if __event_persistence_database_secret is defined %}
+        # Event persistence database credentials
+        - name: EDA_EVENT_PERSISTENCE_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: host
+        - name: EDA_EVENT_PERSISTENCE_DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: port
+        - name: EDA_EVENT_PERSISTENCE_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: database
+        - name: EDA_EVENT_PERSISTENCE_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: username
+        - name: EDA_EVENT_PERSISTENCE_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: password
+        - name: EDA_EVENT_PERSISTENCE_PGSSLMODE
+          value: '{{ event_persistence_postgres_sslmode }}'
+{% endif %}
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}
@@ -258,6 +291,36 @@ spec:
             secretKeyRef:
               name: '{{ __database_secret }}'
               key: host
+{% if __event_persistence_database_secret is defined %}
+        # Event persistence database credentials
+        - name: EDA_EVENT_PERSISTENCE_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: host
+        - name: EDA_EVENT_PERSISTENCE_DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: port
+        - name: EDA_EVENT_PERSISTENCE_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: database
+        - name: EDA_EVENT_PERSISTENCE_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: username
+        - name: EDA_EVENT_PERSISTENCE_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __event_persistence_database_secret }}'
+              key: password
+        - name: EDA_EVENT_PERSISTENCE_PGSSLMODE
+          value: '{{ event_persistence_postgres_sslmode }}'
+{% endif %}
         ports:
         - containerPort: {{ api_django_port }}
         readinessProbe:

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -49,6 +49,10 @@ _database:
   database_secret: ''  # Name of k8s secret containing postgres host, username, password, database, port, and type
 
 
+# Event persistence database configuration
+event_persistence_database_name: "eda_event_persistence"
+event_persistence_database_username: "eda_event_persistence"
+
 image_pull_policy: IfNotPresent
 image_pull_secrets: []
 

--- a/roles/postgres/tasks/create_event_persistence_db.yml
+++ b/roles/postgres/tasks/create_event_persistence_db.yml
@@ -1,0 +1,70 @@
+---
+# Create event persistence database and user in PostgreSQL
+#
+# For EDA managed databases, postgres_pod is already set by create_managed_postgres.yml
+
+- name: Check if event persistence database user exists
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+    container: postgres
+    command: >-
+      psql -tAc "SELECT 1 FROM pg_roles WHERE rolname = '{{ event_persistence_postgres_user }}'"
+  register: event_persistence_user_exists
+  no_log: "{{ no_log }}"
+  when:
+    - postgres_pod['resources'] | length > 0
+
+- name: Create event persistence database user
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+    container: postgres
+    command: >-
+      psql -c "CREATE USER \"{{ event_persistence_postgres_user }}\" WITH PASSWORD '{{ event_persistence_postgres_pass }}';"
+  register: create_event_persistence_user_result
+  failed_when: create_event_persistence_user_result.rc != 0
+  no_log: "{{ no_log }}"
+  when:
+    - postgres_pod['resources'] | length > 0
+    - event_persistence_user_exists.stdout | default('') | trim != '1'
+
+- name: Update event persistence database user password
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+    container: postgres
+    command: >-
+      psql -c "ALTER USER \"{{ event_persistence_postgres_user }}\" WITH PASSWORD '{{ event_persistence_postgres_pass }}';"
+  register: update_event_persistence_user_result
+  failed_when: update_event_persistence_user_result.rc != 0
+  no_log: "{{ no_log }}"
+  when:
+    - postgres_pod['resources'] | length > 0
+    - event_persistence_user_exists.stdout | default('') | trim == '1'
+
+- name: Check if event persistence database exists
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+    container: postgres
+    command: >-
+      psql -tAc "SELECT 1 FROM pg_database WHERE datname = '{{ event_persistence_pg_config['resources'][0]['data']['database'] | b64decode }}'"
+  register: event_persistence_db_exists
+  no_log: "{{ no_log }}"
+  when:
+    - postgres_pod['resources'] | length > 0
+
+- name: Create event persistence database
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+    container: postgres
+    command: >-
+      psql -c "CREATE DATABASE \"{{ event_persistence_pg_config['resources'][0]['data']['database'] | b64decode }}\" WITH OWNER \"{{ event_persistence_postgres_user }}\";"
+  register: create_event_persistence_db_result
+  failed_when: create_event_persistence_db_result.rc != 0
+  no_log: "{{ no_log }}"
+  when:
+    - postgres_pod['resources'] | length > 0
+    - event_persistence_db_exists.stdout | default('') | trim != '1'

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -44,3 +44,19 @@
 - name: Create event stream database user in PostgreSQL
   ansible.builtin.import_tasks: create_event_stream_user.yml
   when: managed_database | bool
+
+# Event persistence database configuration
+# Event persistence is opt-in only. The database is only provisioned when
+# the user explicitly sets event_persistence.deploy_db: true in the CR,
+# or when the AAP gateway operator provides a database_secret.
+- name: Determine and set event persistence postgres configuration secret
+  import_tasks: set_event_persistence_secret.yml
+  when: >-
+    event_persistence.deploy_db | default(false) | bool or
+    (event_persistence.database_secret is defined and event_persistence.database_secret | length > 0)
+
+- name: Create event persistence database in PostgreSQL
+  ansible.builtin.import_tasks: create_event_persistence_db.yml
+  when:
+    - event_persistence.deploy_db | default(false) | bool
+    - managed_database | bool

--- a/roles/postgres/tasks/set_event_persistence_secret.yml
+++ b/roles/postgres/tasks/set_event_persistence_secret.yml
@@ -1,0 +1,62 @@
+---
+# Determine and set event persistence postgres configuration secret
+# When database_secret is provided, use it.
+# Otherwise, auto-generate credentials.
+
+- name: Check for specified event persistence PostgreSQL configuration
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ event_persistence.database_secret }}'
+  register: _custom_event_persistence_pg_config
+  when:
+    - event_persistence.database_secret is defined
+    - event_persistence.database_secret | length
+  no_log: "{{ no_log }}"
+
+- name: Check for existing event persistence PostgreSQL configuration
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ ansible_operator_meta.name }}-event-persistence-postgres-configuration'
+  register: _existing_event_persistence_pg_config
+  no_log: "{{ no_log }}"
+
+- name: Set event persistence PostgreSQL configuration based on if user secret exists
+  ansible.builtin.set_fact:
+    _event_persistence_pg_config: '{{ _custom_event_persistence_pg_config["resources"] | default([]) | length | ternary(_custom_event_persistence_pg_config, _existing_event_persistence_pg_config) }}'
+  no_log: "{{ no_log }}"
+
+- name: Create event persistence database configuration if no secret exists
+  when: not _event_persistence_pg_config['resources'] | default([]) | length
+  block:
+    - name: Create event persistence database configuration
+      kubernetes.core.k8s:
+        apply: true
+        definition: "{{ lookup('template', 'event-persistence-postgres.secret.yaml.j2') }}"
+      no_log: "{{ no_log }}"
+
+    - name: Read event persistence database configuration
+      kubernetes.core.k8s_info:
+        kind: Secret
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        name: '{{ ansible_operator_meta.name }}-event-persistence-postgres-configuration'
+      register: _generated_event_persistence_pg_config
+      no_log: "{{ no_log }}"
+
+- name: Set event persistence PostgreSQL configuration fact
+  ansible.builtin.set_fact:
+    event_persistence_pg_config: '{{ _generated_event_persistence_pg_config["resources"] | default([]) | length | ternary(_generated_event_persistence_pg_config, _event_persistence_pg_config) }}'
+  no_log: "{{ no_log }}"
+
+- name: Set actual event persistence postgres secret name
+  ansible.builtin.set_fact:
+    __event_persistence_database_secret: "{{ event_persistence_pg_config['resources'][0]['metadata']['name'] }}"
+  no_log: "{{ no_log }}"
+
+- name: Store event persistence database configuration vars
+  ansible.builtin.set_fact:
+    event_persistence_postgres_user: "{{ event_persistence_pg_config['resources'][0]['data']['username'] | b64decode }}"
+    event_persistence_postgres_pass: "{{ event_persistence_pg_config['resources'][0]['data']['password'] | b64decode }}"
+    event_persistence_postgres_sslmode: "{{ event_persistence_pg_config['resources'][0]['data']['sslmode'] | default('prefer' | b64encode) | b64decode }}"
+  no_log: "{{ no_log }}"

--- a/roles/postgres/templates/event-persistence-postgres.secret.yaml.j2
+++ b/roles/postgres/templates/event-persistence-postgres.secret.yaml.j2
@@ -1,0 +1,19 @@
+# Event Persistence Postgres Secret.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ ansible_operator_meta.name }}-event-persistence-postgres-configuration'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: 'event-persistence-database'
+stringData:
+  username: '{{ event_persistence_database_username }}'
+  password: '{{ lookup("password", "/dev/null length=32 chars=ascii_letters,digits") }}'
+  database: '{{ event_persistence_database_name }}'
+  port: '{{ eda_postgres_port }}'
+  host: '{{ eda_postgres_host }}'
+  sslmode: '{{ event_persistence_pg_sslmode }}'
+  type: '{{ "managed" if managed_database else "unmanaged" }}'

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -109,6 +109,38 @@
         secrets: "{{ secrets | combine({'eventStreamDatabaseConfigurationSecret': _event_stream_pg_secret}) }}"
       no_log: "{{ no_log }}"
 
+# Handle event persistence database secret for managed deployments
+- name: If deployment is managed, update event persistence database secret host
+  when:
+    - secrets['databaseConfigurationSecret']['data']['type'] | b64decode == 'managed'
+    - secrets['eventPersistenceDatabaseConfigurationSecret'] is defined
+  block:
+    - name: Set tmp event persistence postgres secret dict
+      ansible.builtin.set_fact:
+        _event_persistence_pg_secret: "{{ secrets['eventPersistenceDatabaseConfigurationSecret'] }}"
+      no_log: "{{ no_log }}"
+
+    - name: Change event persistence postgres host and name value
+      ansible.builtin.set_fact:
+        _event_persistence_pg_data: "{{ _event_persistence_pg_secret['data'] | combine({'host': database_host | b64encode }) }}"
+        _event_persistence_pg_secret_name: "{{ deployment_name }}-event-persistence-postgres-configuration"
+      no_log: "{{ no_log }}"
+
+    - name: Override event persistence postgres secret name
+      ansible.builtin.set_fact:
+        _event_persistence_pg_secret: "{{ _event_persistence_pg_secret | combine({'name': _event_persistence_pg_secret_name}) }}"
+      no_log: "{{ no_log }}"
+
+    - name: Override event persistence postgres secret host with new Postgres service
+      ansible.builtin.set_fact:
+        _event_persistence_pg_secret: "{{ _event_persistence_pg_secret | combine({'data': _event_persistence_pg_data}) }}"
+      no_log: "{{ no_log }}"
+
+    - name: Create a new dict of secrets with the new event persistence postgres secret
+      ansible.builtin.set_fact:
+        secrets: "{{ secrets | combine({'eventPersistenceDatabaseConfigurationSecret': _event_persistence_pg_secret}) }}"
+      no_log: "{{ no_log }}"
+
 - name: Apply secret
   k8s:
     state: present


### PR DESCRIPTION
Adding support for event persistence feature. This feature requires a new, dedicated database and the installers can optionally deploy this database, which is controlled via `event_persistence.deploy_db` in the spec. If the user chooses to deploy the db, a new database (`eda_event_persistence`) will be provisioned and credentials will be automatically generated. If a user does not choose to deploy an event persistence db, the feature inside eda-server will not be available.
- Provision a new event persistence database when managed by EDA
- Create database credentials
- Set env vars for eda-server
- Update CI to test deployment with event persistence

https://redhat.atlassian.net/browse/AAP-66372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event persistence database support with configurable deployment options for operator-managed or external database setups.

* **Documentation**
  * Added event persistence database configuration documentation for operators.

* **Testing**
  * Extended CI/CD workflows to include event persistence test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->