### PR TITLE
Fix duplicate Jinja2 closing tag in activation-worker deployment template

### DIFF
--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -60,7 +60,7 @@ spec:
       tolerations:
         {{ combined_activation_worker.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
-{% if combined_activation_worker.topology_spread_constraints is defined %} %}
+{% if combined_activation_worker.topology_spread_constraints is defined %}
       topologySpreadConstraints:
         {{ combined_activation_worker.topology_spread_constraints | to_nice_yaml | indent(width=8) }}
 {% endif %}


### PR DESCRIPTION
The topology_spread_constraints conditional had an extra "%}" token which would break template rendering.

Discovered by @coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a template syntax error that prevented proper conditional rendering of topology spread constraints configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->