### PR TITLE
Add --no-imports to django commands

### DIFF
--- a/roles/eda/tasks/create_admin_user.yml
+++ b/roles/eda/tasks/create_admin_user.yml
@@ -9,7 +9,7 @@
       User = get_user_model();
       nsu = User.objects.filter(is_superuser=True, username=\"{{ admin_user }}\").count();
       exit(0 if nsu > 0 else 1)'
-      | aap-eda-manage shell"
+      | aap-eda-manage shell --no-imports"
   ignore_errors: true
   register: users_result
   changed_when: users_result.return_code > 0

--- a/roles/eda/tasks/update_status.yml
+++ b/roles/eda/tasks/update_status.yml
@@ -31,7 +31,7 @@
         command: >-
           bash -c "echo 'import pkg_resources;
           print(pkg_resources.get_distribution(\"aap-eda\").version)'
-          | aap-eda-manage shell"
+          | aap-eda-manage shell --no-imports"
       register: instance_version
       changed_when: false
 


### PR DESCRIPTION
With django updated to 5.2 in eda then shell commands load imports at startup which flood stdout with logs and break workflows

https://docs.djangoproject.com/en/dev/releases/5.2/#automatic-models-import-in-the-shell

Adding --no-imports to the cli call solves the issue.

https://docs.djangoproject.com/en/5.2/ref/django-admin/#cmdoption-shell-no-imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment automation configurations to optimize Django shell command execution during application initialization and status monitoring processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->