### PR TITLE
Fix other duplicate Jinja2 closing tags

### DIFF
--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -60,7 +60,7 @@ spec:
       tolerations:
         {{ combined_default_worker.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
-{% if combined_default_worker.topology_spread_constraints is defined %} %}
+{% if combined_default_worker.topology_spread_constraints is defined %}
       topologySpreadConstraints:
         {{ combined_default_worker.topology_spread_constraints | to_nice_yaml | indent(width=8) }}
 {% endif %}

--- a/roles/eda/templates/eda-ui.deployment.yaml.j2
+++ b/roles/eda/templates/eda-ui.deployment.yaml.j2
@@ -59,7 +59,7 @@ spec:
       tolerations:
         {{ combined_ui.tolerations | to_nice_yaml | indent(width=8) }}
 {% endif %}
-{% if combined_ui.topology_spread_constraints is defined %} %}
+{% if combined_ui.topology_spread_constraints is defined %}
       topologySpreadConstraints:
         {{ combined_ui.topology_spread_constraints | to_nice_yaml | indent(width=8) }}
 {% endif %}


### PR DESCRIPTION
This was done in ccccc99 for the activation worker deployment but the issue is also present in the default worker and ui deployment templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected template syntax formatting in deployment configuration files to ensure proper parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->