### PR TITLE
ci: Remove redis and scheduler log gathering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,6 @@ jobs:
           echo ::group::POSTGRES_LOGS
           kubectl logs -l app.kubernetes.io/component=database --tail=1000 || true
           echo ::endgroup::
-          echo ::group::REDIS_LOGS
-          kubectl logs -l app.kubernetes.io/component=cache --tail=1000 || true
-          echo ::endgroup::
           echo ::group::EDA_API_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-api --tail=1000 || true
           echo ::endgroup::
@@ -139,9 +136,6 @@ jobs:
           echo ::endgroup::
           echo ::group::EDA_ACTIVATION_WORKER_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-activation-worker --tail=1000 || true
-          echo ::endgroup::
-          echo ::group::EDA_SCHEDULER_LOGS
-          kubectl logs -l app.kubernetes.io/component=eda-scheduler --tail=1000 || true
           echo ::endgroup::
   validate-bundle:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -119,9 +119,6 @@ jobs:
           echo ::group::POSTGRES_LOGS
           kubectl logs -l app.kubernetes.io/component=database --tail=1000 || true
           echo ::endgroup::
-          echo ::group::REDIS_LOGS
-          kubectl logs -l app.kubernetes.io/component=cache --tail=1000 || true
-          echo ::endgroup::
           echo ::group::EDA_API_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-api --tail=1000 || true
           echo ::endgroup::
@@ -133,9 +130,6 @@ jobs:
           echo ::endgroup::
           echo ::group::EDA_ACTIVATION_WORKER_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-activation-worker --tail=1000 || true
-          echo ::endgroup::
-          echo ::group::EDA_SCHEDULER_LOGS
-          kubectl logs -l app.kubernetes.io/component=eda-scheduler --tail=1000 || true
           echo ::endgroup::
   validate-bundle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Both redis and scheduler deployments were removed not so long ago so we don't need to gather logs for those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflow logging by removing certain log collection steps from automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->