### PR TITLE
ci: Add API init container to logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
           echo ::endgroup::
           echo ::group::EDA_API_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-api --tail=1000 || true
+          kubectl logs -l app.kubernetes.io/component=eda-api -c run-migrations --tail=1000 || true
+          kubectl logs -l app.kubernetes.io/component=eda-api -c eda-initial-data --tail=1000 || true
           echo ::endgroup::
           echo ::group::EDA_UI_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-ui --tail=1000 || true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -121,6 +121,8 @@ jobs:
           echo ::endgroup::
           echo ::group::EDA_API_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-api --tail=1000 || true
+          kubectl logs -l app.kubernetes.io/component=eda-api -c run-migrations --tail=1000 || true
+          kubectl logs -l app.kubernetes.io/component=eda-api -c eda-initial-data --tail=1000 || true
           echo ::endgroup::
           echo ::group::EDA_UI_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-ui --tail=1000 || true


### PR DESCRIPTION
When gathering container logs, we're not including init containers logs so if something failed during that step those logs aren't gathered.