### PR TITLE
ci: Add external postgresql logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,12 @@ jobs:
           kubectl logs -l control-plane=controller-manager --tail=10000 || true
           echo ::endgroup::
           echo ::group::POSTGRES_LOGS
-          kubectl logs -l app.kubernetes.io/component=database --tail=1000 || true
+          if [[ "${{ matrix.SCENARIO }}" == "externaldb" ]]; then
+            eval $(minikube -p minikube docker-env)
+            docker logs postgresql --tail 1000 || true
+          else
+            kubectl logs -l app.kubernetes.io/component=database --tail=1000 || true
+          fi
           echo ::endgroup::
           echo ::group::EDA_API_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-api --tail=1000 || true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,7 +117,12 @@ jobs:
           kubectl logs -l control-plane=controller-manager --tail=20000 || true
           echo ::endgroup::
           echo ::group::POSTGRES_LOGS
-          kubectl logs -l app.kubernetes.io/component=database --tail=1000 || true
+          if [[ "${{ matrix.SCENARIO }}" == "externaldb" ]]; then
+            eval $(minikube -p minikube docker-env)
+            docker logs postgresql --tail 1000 || true
+          else
+            kubectl logs -l app.kubernetes.io/component=database --tail=1000 || true
+          fi
           echo ::endgroup::
           echo ::group::EDA_API_LOGS
           kubectl logs -l app.kubernetes.io/component=eda-api --tail=1000 || true


### PR DESCRIPTION
Only the internal managed postgresql pod get logs gathered at the end of the CI run.
When using an external database (like one of the CI scenario) then those logs aren't gathered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline logging capabilities to better support different database scenarios during automated testing.
  * Improved database log collection mechanisms to ensure comprehensive diagnostics across multiple test deployment configurations.
  * Streamlined log retrieval processes for various environment setups to improve debugging efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->