### PR TITLE
feat: add proxy env var support for EDA containers

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2558,9 +2558,18 @@ spec:
               force_drop_db:
                 description: Force drop the database before restoring. USE WITH CAUTION!
                 type: boolean
+              http_proxy:
+                description: HTTP proxy URL to configure on EDA containers
+                type: string
+              https_proxy:
+                description: HTTPS proxy URL to configure on EDA containers
+                type: string
               idle_deployment:
                 description: Scale down deployments to put EDA into an idle state
                 type: boolean
+              no_proxy:
+                description: Comma-separated list of hosts that bypass the proxy on EDA containers
+                type: string
               old_postgres_configuration_secret:
                 description: Secret where the old database configuration can be found for data migration
                 type: string

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -740,6 +740,24 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: HTTP proxy URL to configure on EDA containers
+        displayName: HTTP Proxy
+        path: http_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HTTPS proxy URL to configure on EDA containers
+        displayName: HTTPS Proxy
+        path: https_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma-separated list of hosts that bypass the proxy on EDA containers
+        displayName: No Proxy
+        path: no_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Service Account Annotations
         path: service_account_annotations
         x-descriptors:

--- a/config/samples/eda_v1alpha1_eda.yaml
+++ b/config/samples/eda_v1alpha1_eda.yaml
@@ -45,3 +45,7 @@ spec:
     storage_requirements:
       requests:
         storage: 20Gi
+  # HTTP proxy settings (optional)
+  # http_proxy: "http://proxy.example.com:3128"
+  # https_proxy: "http://proxy.example.com:3128"
+  # no_proxy: "localhost,127.0.0.1,.cluster.local"

--- a/molecule/default/tasks/proxy_env_var_test.yml
+++ b/molecule/default/tasks/proxy_env_var_test.yml
@@ -1,0 +1,144 @@
+---
+- name: Patch EDA CR to set proxy env vars
+  kubernetes.core.k8s:
+    state: patched
+    api_version: eda.ansible.com/v1alpha1
+    kind: EDA
+    name: eda-sample
+    namespace: '{{ namespace }}'
+    definition:
+      spec:
+        http_proxy: 'http://localhost:3128'
+        https_proxy: 'http://localhost:3128'
+        no_proxy: 'localhost,127.0.0.1,.cluster.local,.svc'
+
+# -------------------------------------------------------------------------
+# ConfigMap assertions
+# -------------------------------------------------------------------------
+- name: Wait for proxy-env ConfigMap to be created
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: ConfigMap
+    name: 'eda-sample-proxy-env'
+  register: proxy_configmap
+  until: proxy_configmap.resources | length > 0
+  retries: 30
+  delay: 10
+
+- name: Assert proxy-env ConfigMap has correct data
+  ansible.builtin.assert:
+    that:
+      - proxy_configmap.resources[0].data.HTTP_PROXY == 'http://localhost:3128'
+      - proxy_configmap.resources[0].data.http_proxy == 'http://localhost:3128'
+      - proxy_configmap.resources[0].data.HTTPS_PROXY == 'http://localhost:3128'
+      - proxy_configmap.resources[0].data.https_proxy == 'http://localhost:3128'
+      - proxy_configmap.resources[0].data.NO_PROXY == 'localhost,127.0.0.1,.cluster.local,.svc'
+      - proxy_configmap.resources[0].data.no_proxy == 'localhost,127.0.0.1,.cluster.local,.svc'
+    fail_msg: proxy-env ConfigMap is missing one or more expected proxy values
+
+# -------------------------------------------------------------------------
+# Deployment envFrom assertions
+# -------------------------------------------------------------------------
+- name: Get eda-api deployment
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Deployment
+    label_selectors:
+      - app.kubernetes.io/name = eda-sample
+      - app.kubernetes.io/component = eda-api
+  register: api_deployment
+
+- name: Assert eda-api containers reference proxy-env ConfigMap via envFrom
+  ansible.builtin.assert:
+    that:
+      - api_deployment.resources[0].spec.template.spec.containers |
+        map(attribute='envFrom', default=[]) | flatten |
+        selectattr('configMapRef.name', 'defined') |
+        selectattr('configMapRef.name', 'equalto', 'eda-sample-proxy-env') | list | length > 0
+    fail_msg: eda-api containers are missing envFrom reference to eda-sample-proxy-env
+
+- name: Get eda-default-worker deployment
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Deployment
+    label_selectors:
+      - app.kubernetes.io/name = eda-sample
+      - app.kubernetes.io/component = eda-default-worker
+  register: default_worker_deployment
+
+- name: Assert eda-default-worker containers reference proxy-env ConfigMap via envFrom
+  ansible.builtin.assert:
+    that:
+      - default_worker_deployment.resources[0].spec.template.spec.containers |
+        map(attribute='envFrom', default=[]) | flatten |
+        selectattr('configMapRef.name', 'defined') |
+        selectattr('configMapRef.name', 'equalto', 'eda-sample-proxy-env') | list | length > 0
+    fail_msg: eda-default-worker containers are missing envFrom reference to eda-sample-proxy-env
+
+- name: Get eda-activation-worker deployment
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Deployment
+    label_selectors:
+      - app.kubernetes.io/name = eda-sample
+      - app.kubernetes.io/component = eda-activation-worker
+  register: activation_worker_deployment
+
+- name: Assert eda-activation-worker containers reference proxy-env ConfigMap via envFrom
+  ansible.builtin.assert:
+    that:
+      - activation_worker_deployment.resources[0].spec.template.spec.containers |
+        map(attribute='envFrom', default=[]) | flatten |
+        selectattr('configMapRef.name', 'defined') |
+        selectattr('configMapRef.name', 'equalto', 'eda-sample-proxy-env') | list | length > 0
+    fail_msg: eda-activation-worker containers are missing envFrom reference to eda-sample-proxy-env
+
+- name: Get eda-event-stream deployment
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Deployment
+    label_selectors:
+      - app.kubernetes.io/name = eda-sample
+      - app.kubernetes.io/component = eda-event-stream
+  register: event_stream_deployment
+
+- name: Assert eda-event-stream containers reference proxy-env ConfigMap via envFrom
+  ansible.builtin.assert:
+    that:
+      - event_stream_deployment.resources[0].spec.template.spec.containers |
+        map(attribute='envFrom', default=[]) | flatten |
+        selectattr('configMapRef.name', 'defined') |
+        selectattr('configMapRef.name', 'equalto', 'eda-sample-proxy-env') | list | length > 0
+    fail_msg: eda-event-stream containers are missing envFrom reference to eda-sample-proxy-env
+
+# -------------------------------------------------------------------------
+# Cleanup and verify ConfigMap removal
+# -------------------------------------------------------------------------
+- name: Clear proxy env vars from EDA CR after test
+  kubernetes.core.k8s:
+    state: patched
+    api_version: eda.ansible.com/v1alpha1
+    kind: EDA
+    name: eda-sample
+    namespace: '{{ namespace }}'
+    definition:
+      spec:
+        http_proxy: null
+        https_proxy: null
+        no_proxy: null
+
+- name: Wait for proxy-env ConfigMap to be deleted
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: ConfigMap
+    name: 'eda-sample-proxy-env'
+  register: proxy_configmap_after
+  until: proxy_configmap_after.resources | length == 0
+  retries: 30
+  delay: 10
+
+- name: Assert proxy-env ConfigMap is removed when proxy vars cleared
+  ansible.builtin.assert:
+    that:
+      - proxy_configmap_after.resources | length == 0
+    fail_msg: proxy-env ConfigMap still exists after clearing proxy vars from CR

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -148,6 +148,14 @@ hostname: ''
 # Secret to lookup that provides the custom CA trusted bundle
 bundle_cacert_secret: ''
 
+# Proxy environment variables for EDA containers.
+# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
+# proxy object). Set these fields in the CR spec to override the inherited values
+# per instance.
+http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
+https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
+no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"
+
 # Secret to lookup that provide the secret key
 # #
 db_fields_encryption_secret: ''

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -25,6 +25,12 @@
     definition: "{{ lookup('template', 'eda.configmap.yaml.j2') }}"
     wait: yes
 
+- name: Apply proxy environment ConfigMap
+  k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'eda-proxy-env.configmap.yaml.j2') }}"
+    state: "{{ 'present' if (http_proxy or https_proxy or no_proxy) else 'absent' }}"
+
 - name: Apply Redirect Page Configmap
   k8s:
     apply: yes

--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -39,6 +39,9 @@ spec:
   ] %}
         checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-eda-proxy-env-configmap: "{{ lookup('template', 'eda-proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
 {% for secret in [
     "secrets/db_fields_encryption",
   ] %}
@@ -75,6 +78,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:
@@ -176,6 +182,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -44,6 +44,9 @@ spec:
   ] %}
         checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-eda-proxy-env-configmap: "{{ lookup('template', 'eda-proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
 {% for secret in [
     "secrets/db_fields_encryption",
   ] %}
@@ -86,6 +89,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:
@@ -132,6 +138,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: ANSIBLE_REVERSE_RESOURCE_SYNC
           value: 'false'
@@ -255,6 +264,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:
@@ -355,6 +367,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:

--- a/roles/eda/templates/eda-default-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-default-worker.deployment.yaml.j2
@@ -39,6 +39,9 @@ spec:
   ] %}
         checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-eda-proxy-env-configmap: "{{ lookup('template', 'eda-proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
 {% for secret in [
     "secrets/db_fields_encryption",
   ] %}
@@ -75,6 +78,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:
@@ -146,6 +152,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:

--- a/roles/eda/templates/eda-event-stream.deployment.yaml.j2
+++ b/roles/eda/templates/eda-event-stream.deployment.yaml.j2
@@ -39,6 +39,9 @@ spec:
   ] %}
         checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-eda-proxy-env-configmap: "{{ lookup('template', 'eda-proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
 {% for secret in [
     "secrets/db_fields_encryption",
   ] %}
@@ -75,6 +78,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:
@@ -146,6 +152,9 @@ spec:
         envFrom:
           - configMapRef:
               name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         env:
         - name: EDA_DB_HOST
           valueFrom:

--- a/roles/eda/templates/eda-proxy-env.configmap.yaml.j2
+++ b/roles/eda/templates/eda-proxy-env.configmap.yaml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ ansible_operator_meta.name }}-proxy-env'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+data:
+{% if http_proxy %}
+  HTTP_PROXY: '{{ http_proxy }}'
+  http_proxy: '{{ http_proxy }}'
+{% endif %}
+{% if https_proxy %}
+  HTTPS_PROXY: '{{ https_proxy }}'
+  https_proxy: '{{ https_proxy }}'
+{% endif %}
+{% if no_proxy %}
+  NO_PROXY: '{{ no_proxy }}'
+  no_proxy: '{{ no_proxy }}'
+{% endif %}


### PR DESCRIPTION
Add http_proxy, https_proxy, and no_proxy CRD fields to the EDA spec.

Add the proxy-aware OLM annotation to the CSV so that OLM injects cluster proxy configuration into the operator manager pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added proxy configuration options: http_proxy, https_proxy, and no_proxy (including bypass list).
  * Containers now receive proxy environment variables (both upper- and lowercase) when configured.
  * Operator metadata marked as proxy-aware.
  * Sample config includes commented proxy examples.

* **Chores**
  * Added defaults that resolve proxy values from environment variables.

* **Tests**
  * Added tests to validate proxy env var injection across deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->