### PR TITLE
fix(eda-api): mount bundle_cacert volumes in gunicorn container

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -340,10 +340,20 @@ spec:
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}
-{% if not ui_disabled %}
+{% if not ui_disabled or bundle_ca_crt %}
         volumeMounts:
+{% if not ui_disabled %}
         - name: static-files
           mountPath: {{ static_path }}
+{% endif %}
+{% if bundle_ca_crt %}
+        - name: "ca-trust-extracted"
+          mountPath: "/etc/pki/ca-trust/extracted"
+        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+          mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+          subPath: bundle-ca.crt
+          readOnly: true
+{% endif %}
 {% endif %}
       - name: daphne
         image: {{ _image }}


### PR DESCRIPTION
  The configure-bundle-ca-cert initContainer prepares the custom CA trust
  store but the resulting volumes were only mounted in the daphne container,
  not in eda-api (gunicorn). This caused SSL verification failures for
  outbound HTTPS calls from the API process (e.g. credential lookups
  against a GitHub Enterprise instance with a self-signed CA).

  Add ca-trust-extracted and bundle-cacert volume mounts to the eda-api
  container when bundle_ca_crt is set, matching the existing pattern in
  daphne and worker deployments.

AAP-72822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom Certificate Authority (CA) bundles are now supported in the deployment configuration. When a CA bundle is provided, it is automatically mounted and integrated into the container's certificate trust store, enabling secure communications with endpoints using custom certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->