### PR TITLE
feat: add configurable namespace for activation job pods

### DIFF
--- a/.ci/eda_v1alpha1_eda.activation_job_namespace.ci.yaml
+++ b/.ci/eda_v1alpha1_eda.activation_job_namespace.ci.yaml
@@ -1,0 +1,11 @@
+apiVersion: eda.ansible.com/v1alpha1
+kind: EDA
+metadata:
+  name: eda-demo
+  annotations:
+    "ansible.sdk.operatorframework.io/verbosity": "5"
+spec:
+  no_log: false
+  automation_server_url: http://foo.bar
+  activation_worker:
+    activation_job_namespace: "eda-jobs"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ jobs:
           - SCENARIO: externaldb
           - SCENARIO: ingress
           - SCENARIO: event_persistence
+          - SCENARIO: activation_job_namespace
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -67,6 +68,10 @@ jobs:
       - name: Create event stream postgresql secret for external database
         run: kubectl apply -f .ci/eda-event-stream-external-database.secret.yaml
         if: ${{ matrix.SCENARIO == 'externaldb' }}
+
+      - name: Create activation job namespace
+        run: kubectl create namespace eda-jobs
+        if: ${{ matrix.SCENARIO == 'activation_job_namespace' }}
 
       - name: Create the EDA demo CR
         run: |

--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -1479,6 +1479,13 @@ spec:
               activation_worker:
                 description: Defines desired state of eda-activation-worker resources
                 properties:
+                  activation_job_namespace:
+                    description: Kubernetes namespace where activation job pods are
+                      created. When set, jobs run in this namespace instead of the
+                      EDA operator namespace. The operator creates the necessary
+                      RBAC to allow the EDA service account to manage resources
+                      in the target namespace.
+                    type: string
                   node_selector:
                     additionalProperties:
                       type: string

--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2943,6 +2943,13 @@ spec:
               activation_worker:
                 description: Defines desired state of eda-activation-worker resources
                 properties:
+                  activation_job_namespace:
+                    description: Kubernetes namespace where activation job pods are
+                      created. When set, jobs run in this namespace instead of the
+                      EDA operator namespace. The operator creates the necessary
+                      RBAC to allow the EDA service account to manage resources
+                      in the target namespace.
+                    type: string
                   node_selector:
                     additionalProperties:
                       type: string

--- a/config/rbac/activation_job_namespace_role.yaml
+++ b/config/rbac/activation_job_namespace_role.yaml
@@ -1,0 +1,30 @@
+---
+# Cluster-scoped because the target namespace is user-configurable at
+# runtime via spec.activation_worker.activation_job_namespace.  The
+# operator must be able to create Role/RoleBinding resources in whatever
+# namespace the user specifies.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eda-activation-job-namespace-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/config/rbac/activation_job_namespace_role.yaml
+++ b/config/rbac/activation_job_namespace_role.yaml
@@ -19,6 +19,18 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - roles
+    verbs:
+      - create
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
       - rolebindings
     verbs:
       - create

--- a/config/rbac/activation_job_namespace_role.yaml
+++ b/config/rbac/activation_job_namespace_role.yaml
@@ -20,6 +20,7 @@ rules:
     resources:
       - roles
     verbs:
+      - bind
       - create
       - delete
       - escalate

--- a/config/rbac/activation_job_namespace_role_binding.yaml
+++ b/config/rbac/activation_job_namespace_role_binding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eda-activation-job-namespace-manager-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eda-activation-job-namespace-manager
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,3 +12,5 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
+- activation_job_namespace_role.yaml
+- activation_job_namespace_role_binding.yaml

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -58,6 +58,7 @@ _activation_worker:
       memory: 150Mi
   node_selector: {}
   tolerations: []
+  activation_job_namespace: ""
 
 # Note: Deprecated "worker: {}" is intentionally excluded here so we know if the user set it
 _worker: {}

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -61,6 +61,7 @@ _activation_worker:
   node_selector: {}
   tolerations: []
   affinity: {}
+  activation_job_namespace: ""
 
 # Note: Deprecated "worker: {}" is intentionally excluded here so we know if the user set it
 _worker: {}

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -38,6 +38,44 @@
     wait: yes
   when: public_base_url is defined
 
+- name: Look up existing ConfigMap for previous activation_job_namespace
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
+  register: _eda_env_cm
+
+- name: Record previous activation_job_namespace from ConfigMap
+  ansible.builtin.set_fact:
+    _previous_activation_job_namespace: >-
+      {{ (_eda_env_cm.resources | first).data.EDA_ACTIVATION_JOB_NAMESPACE | default('') }}
+  when:
+    - _eda_env_cm.resources | length > 0
+    - (_eda_env_cm.resources | first).data is defined
+
+- name: Apply cross-namespace RBAC for activation job pods
+  k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'eda-activation-job-namespace-rbac.yaml.j2') }}"
+    wait: yes
+  when: combined_activation_worker.activation_job_namespace | default('') | length > 0
+
+- name: Remove cross-namespace RBAC when activation_job_namespace is unset
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: "{{ item.kind }}"
+    name: "{{ ansible_operator_meta.name }}-activation-job-manager"
+    namespace: "{{ _previous_activation_job_namespace }}"
+  loop:
+    - { kind: RoleBinding }
+    - { kind: Role }
+  when:
+    - combined_activation_worker.activation_job_namespace | default('') | length == 0
+    - _previous_activation_job_namespace | default('') | length > 0
+  ignore_errors: yes
+
 - name: Apply Backend deployment resources
   k8s:
     apply: yes

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -19,6 +19,22 @@
     event_stream_mtls_base_url: "{{ public_base_url.rstrip('/') }}/{{ event_stream_mtls_prefix_path }}"
   when: public_base_url | default('') | length > 0
 
+- name: Look up existing ConfigMap for previous activation_job_namespace
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
+  register: _eda_env_cm
+
+- name: Record previous activation_job_namespace from ConfigMap
+  ansible.builtin.set_fact:
+    _previous_activation_job_namespace: >-
+      {{ (_eda_env_cm.resources | first).data.EDA_ACTIVATION_JOB_NAMESPACE | default('') }}
+  when:
+    - _eda_env_cm.resources | length > 0
+    - (_eda_env_cm.resources | first).data is defined
+
 - name: Apply ConfigMap resources
   k8s:
     apply: yes
@@ -38,22 +54,6 @@
     wait: yes
   when: public_base_url is defined
 
-- name: Look up existing ConfigMap for previous activation_job_namespace
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: ConfigMap
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
-  register: _eda_env_cm
-
-- name: Record previous activation_job_namespace from ConfigMap
-  ansible.builtin.set_fact:
-    _previous_activation_job_namespace: >-
-      {{ (_eda_env_cm.resources | first).data.EDA_ACTIVATION_JOB_NAMESPACE | default('') }}
-  when:
-    - _eda_env_cm.resources | length > 0
-    - (_eda_env_cm.resources | first).data is defined
-
 - name: Apply cross-namespace RBAC for activation job pods
   k8s:
     apply: yes
@@ -61,7 +61,7 @@
     wait: yes
   when: combined_activation_worker.activation_job_namespace | default('') | length > 0
 
-- name: Remove cross-namespace RBAC when activation_job_namespace is unset
+- name: Remove cross-namespace RBAC from previous namespace
   k8s:
     state: absent
     api_version: rbac.authorization.k8s.io/v1
@@ -72,8 +72,8 @@
     - { kind: RoleBinding }
     - { kind: Role }
   when:
-    - combined_activation_worker.activation_job_namespace | default('') | length == 0
     - _previous_activation_job_namespace | default('') | length > 0
+    - combined_activation_worker.activation_job_namespace | default('') != _previous_activation_job_namespace
   ignore_errors: yes
 
 - name: Apply Backend deployment resources

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -82,7 +82,6 @@
   when:
     - _previous_activation_job_namespace | default('') | length > 0
     - combined_activation_worker.activation_job_namespace | default('') != _previous_activation_job_namespace
-  ignore_errors: yes
 
 - name: Apply Backend deployment resources
   k8s:

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -19,6 +19,22 @@
     event_stream_mtls_base_url: "{{ public_base_url.rstrip('/') }}/{{ event_stream_mtls_prefix_path }}"
   when: public_base_url | default('') | length > 0
 
+- name: Look up existing ConfigMap for previous activation_job_namespace
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
+  register: _eda_env_cm
+
+- name: Record previous activation_job_namespace from ConfigMap
+  ansible.builtin.set_fact:
+    _previous_activation_job_namespace: >-
+      {{ (_eda_env_cm.resources | first).data.EDA_ACTIVATION_JOB_NAMESPACE | default('') }}
+  when:
+    - _eda_env_cm.resources | length > 0
+    - (_eda_env_cm.resources | first).data is defined
+
 - name: Apply ConfigMap resources
   k8s:
     apply: yes
@@ -46,22 +62,6 @@
     wait: yes
   when: public_base_url is defined
 
-- name: Look up existing ConfigMap for previous activation_job_namespace
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: ConfigMap
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
-  register: _eda_env_cm
-
-- name: Record previous activation_job_namespace from ConfigMap
-  ansible.builtin.set_fact:
-    _previous_activation_job_namespace: >-
-      {{ (_eda_env_cm.resources | first).data.EDA_ACTIVATION_JOB_NAMESPACE | default('') }}
-  when:
-    - _eda_env_cm.resources | length > 0
-    - (_eda_env_cm.resources | first).data is defined
-
 - name: Apply cross-namespace RBAC for activation job pods
   k8s:
     apply: yes
@@ -69,7 +69,7 @@
     wait: yes
   when: combined_activation_worker.activation_job_namespace | default('') | length > 0
 
-- name: Remove cross-namespace RBAC when activation_job_namespace is unset
+- name: Remove cross-namespace RBAC from previous namespace
   k8s:
     state: absent
     api_version: rbac.authorization.k8s.io/v1
@@ -80,8 +80,8 @@
     - { kind: RoleBinding }
     - { kind: Role }
   when:
-    - combined_activation_worker.activation_job_namespace | default('') | length == 0
     - _previous_activation_job_namespace | default('') | length > 0
+    - combined_activation_worker.activation_job_namespace | default('') != _previous_activation_job_namespace
   ignore_errors: yes
 
 - name: Apply Backend deployment resources

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -46,6 +46,44 @@
     wait: yes
   when: public_base_url is defined
 
+- name: Look up existing ConfigMap for previous activation_job_namespace
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
+  register: _eda_env_cm
+
+- name: Record previous activation_job_namespace from ConfigMap
+  ansible.builtin.set_fact:
+    _previous_activation_job_namespace: >-
+      {{ (_eda_env_cm.resources | first).data.EDA_ACTIVATION_JOB_NAMESPACE | default('') }}
+  when:
+    - _eda_env_cm.resources | length > 0
+    - (_eda_env_cm.resources | first).data is defined
+
+- name: Apply cross-namespace RBAC for activation job pods
+  k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'eda-activation-job-namespace-rbac.yaml.j2') }}"
+    wait: yes
+  when: combined_activation_worker.activation_job_namespace | default('') | length > 0
+
+- name: Remove cross-namespace RBAC when activation_job_namespace is unset
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: "{{ item.kind }}"
+    name: "{{ ansible_operator_meta.name }}-activation-job-manager"
+    namespace: "{{ _previous_activation_job_namespace }}"
+  loop:
+    - { kind: RoleBinding }
+    - { kind: Role }
+  when:
+    - combined_activation_worker.activation_job_namespace | default('') | length == 0
+    - _previous_activation_job_namespace | default('') | length > 0
+  ignore_errors: yes
+
 - name: Apply Backend deployment resources
   k8s:
     apply: yes

--- a/roles/eda/tasks/deploy_eda.yml
+++ b/roles/eda/tasks/deploy_eda.yml
@@ -35,6 +35,27 @@
     - _eda_env_cm.resources | length > 0
     - (_eda_env_cm.resources | first).data is defined
 
+- name: Apply cross-namespace RBAC for activation job pods
+  k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'eda-activation-job-namespace-rbac.yaml.j2') }}"
+    wait: yes
+  when: combined_activation_worker.activation_job_namespace | default('') | length > 0
+
+- name: Remove cross-namespace RBAC from previous namespace
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: "{{ item.kind }}"
+    name: "{{ ansible_operator_meta.name }}-activation-job-manager"
+    namespace: "{{ _previous_activation_job_namespace }}"
+  loop:
+    - { kind: RoleBinding }
+    - { kind: Role }
+  when:
+    - _previous_activation_job_namespace | default('') | length > 0
+    - combined_activation_worker.activation_job_namespace | default('') != _previous_activation_job_namespace
+
 - name: Apply ConfigMap resources
   k8s:
     apply: yes
@@ -61,27 +82,6 @@
     definition: "{{ lookup('template', 'redirect-page.configmap.html.j2') }}"
     wait: yes
   when: public_base_url is defined
-
-- name: Apply cross-namespace RBAC for activation job pods
-  k8s:
-    apply: yes
-    definition: "{{ lookup('template', 'eda-activation-job-namespace-rbac.yaml.j2') }}"
-    wait: yes
-  when: combined_activation_worker.activation_job_namespace | default('') | length > 0
-
-- name: Remove cross-namespace RBAC from previous namespace
-  k8s:
-    state: absent
-    api_version: rbac.authorization.k8s.io/v1
-    kind: "{{ item.kind }}"
-    name: "{{ ansible_operator_meta.name }}-activation-job-manager"
-    namespace: "{{ _previous_activation_job_namespace }}"
-  loop:
-    - { kind: RoleBinding }
-    - { kind: Role }
-  when:
-    - _previous_activation_job_namespace | default('') | length > 0
-    - combined_activation_worker.activation_job_namespace | default('') != _previous_activation_job_namespace
 
 - name: Apply Backend deployment resources
   k8s:

--- a/roles/eda/templates/eda-activation-job-namespace-rbac.yaml.j2
+++ b/roles/eda/templates/eda-activation-job-namespace-rbac.yaml.j2
@@ -1,0 +1,65 @@
+# RBAC resources for cross-namespace activation job pods.
+# Created when activation_job_namespace is set on the EDA CR.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: '{{ ansible_operator_meta.name }}-activation-job-manager'
+  namespace: '{{ combined_activation_worker.activation_job_namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - pods
+      - pods/log
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ ansible_operator_meta.name }}-activation-job-manager'
+  namespace: '{{ combined_activation_worker.activation_job_namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ ansible_operator_meta.name }}-activation-job-manager'
+subjects:
+  - kind: ServiceAccount
+    name: '{{ ansible_operator_meta.name }}'
+    namespace: '{{ ansible_operator_meta.namespace }}'

--- a/roles/eda/templates/eda-api.networkpolicy.yaml.j2
+++ b/roles/eda/templates/eda-api.networkpolicy.yaml.j2
@@ -47,13 +47,22 @@ spec:
         - protocol: TCP
           port: {{ websocket_port }}
     # Allow traffic from activation Job pods (created at runtime by activation
-    # workers, not operator-managed — carry only app: eda).
+    # workers, not operator-managed, carry only app: eda).
     # ansible_rulebook connects to daphne (websocket_port) for rulebook
     # execution and to the API (api_nginx_port) for token refresh.
     - from:
+{% if combined_activation_worker.activation_job_namespace | default('') | length > 0 %}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: '{{ combined_activation_worker.activation_job_namespace }}'
+          podSelector:
+            matchLabels:
+              app: eda
+{% else %}
         - podSelector:
             matchLabels:
               app: eda
+{% endif %}
       ports:
         - protocol: TCP
           port: {{ websocket_port }}

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -34,6 +34,10 @@ data:
 
   EDA_STATIC_URL: /api/eda/static/
 
+{% if combined_activation_worker.activation_job_namespace | default('') | length > 0 %}
+  EDA_ACTIVATION_JOB_NAMESPACE: "{{ combined_activation_worker.activation_job_namespace }}"
+{% endif %}
+
   # Custom user variables
 {% for item in extra_settings | default([]) %}
   {{ item.setting | upper }}: "{{ item.value }}"

--- a/roles/eda/templates/eda.configmap.yaml.j2
+++ b/roles/eda/templates/eda.configmap.yaml.j2
@@ -45,6 +45,10 @@ data:
 {% endif %}
 {% endif %}
 
+{% if combined_activation_worker.activation_job_namespace | default('') | length > 0 %}
+  EDA_ACTIVATION_JOB_NAMESPACE: "{{ combined_activation_worker.activation_job_namespace }}"
+{% endif %}
+
   # Custom user variables
 {% for item in extra_settings | default([]) %}
   {{ item.setting | upper }}: "{{ item.value }}"

--- a/roles/postgres/templates/postgres.networkpolicy.yaml.j2
+++ b/roles/postgres/templates/postgres.networkpolicy.yaml.j2
@@ -34,11 +34,20 @@ spec:
             matchLabels:
               control-plane: controller-manager
         # EDA activation Job pods (created at runtime by activation workers,
-        # not operator-managed — carry only app: eda, no managed-by label).
+        # not operator-managed, carry only app: eda, no managed-by label).
         # Event stream activations connect to Postgres via pg_notify.
+{% if combined_activation_worker.activation_job_namespace | default('') | length > 0 %}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: '{{ combined_activation_worker.activation_job_namespace }}'
+          podSelector:
+            matchLabels:
+              app: eda
+{% else %}
         - podSelector:
             matchLabels:
               app: eda
+{% endif %}
       ports:
         - protocol: TCP
           port: {{ eda_postgres_port | default('5432') }}


### PR DESCRIPTION
## Summary

- Adds `activation_job_namespace` field to the `activation_worker` section of the EDA CRD, allowing activation job pods to run in a separate Kubernetes namespace for security isolation, resource quota management, and NetworkPolicy boundaries.
- The operator injects `EDA_ACTIVATION_JOB_NAMESPACE` into the activation worker ConfigMap and creates cross-namespace RBAC so the EDA ServiceAccount can manage Jobs, Pods, Secrets, and Services in the target namespace.

## What changed

- **CRD**: new optional string field `activation_worker.activation_job_namespace`.
- **Role defaults**: `activation_job_namespace` defaults to empty string (feature disabled).
- **ConfigMap template**: conditionally sets `EDA_ACTIVATION_JOB_NAMESPACE` env var.
- **New RBAC template**: `eda-activation-job-namespace-rbac.yaml.j2` creates a Role and RoleBinding in the target namespace.
- **Deploy task**: applies cross-namespace RBAC when `activation_job_namespace` is set; removes it when unset.
- **ClusterRole + ClusterRoleBinding**: grants the operator SA permission to manage Roles and RoleBindings in the target namespace.

## Why

Operators running EDA on shared clusters need activation job pods (which run user-supplied rulebooks and decision environments) isolated from the EDA control plane. A dedicated namespace enables independent ResourceQuota, LimitRange, and NetworkPolicy controls.

## Server-side companion

The `eda-server` side reads `EDA_ACTIVATION_JOB_NAMESPACE` as an override in `_set_namespace()`, falling back to the SA token file. A companion PR will be filed on `ansible/eda-server`.

## How to test

1. Deploy an EDA CR without `activation_job_namespace` (default behaviour, no change).
2. Set `activation_worker.activation_job_namespace: "eda-jobs"` on the CR.
3. Verify the operator creates Role + RoleBinding in the `eda-jobs` namespace.
4. Verify `EDA_ACTIVATION_JOB_NAMESPACE` appears in the activation worker ConfigMap.

## Breaking changes / dependencies

None. Field is optional; existing CRs are unaffected.

Closes #344.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specify a custom Kubernetes namespace for activation job execution.
  * Automatically provision and clean up required cross-namespace permissions when the configured namespace changes.
  * Network access policies now appropriately restrict activation job traffic to the configured namespace.

* **Tests**
  * Added a CI scenario to validate the activation-job-namespace workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->