### PR TITLE
refactor: remove proxy env var CRD fields and CSV specDescriptors

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2558,18 +2558,9 @@ spec:
               force_drop_db:
                 description: Force drop the database before restoring. USE WITH CAUTION!
                 type: boolean
-              http_proxy:
-                description: HTTP proxy URL to configure on EDA containers
-                type: string
-              https_proxy:
-                description: HTTPS proxy URL to configure on EDA containers
-                type: string
               idle_deployment:
                 description: Scale down deployments to put EDA into an idle state
                 type: boolean
-              no_proxy:
-                description: Comma-separated list of hosts that bypass the proxy on EDA containers
-                type: string
               old_postgres_configuration_secret:
                 description: Secret where the old database configuration can be found for data migration
                 type: string

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -740,24 +740,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: HTTP proxy URL to configure on EDA containers
-        displayName: HTTP Proxy
-        path: http_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: HTTPS proxy URL to configure on EDA containers
-        displayName: HTTPS Proxy
-        path: https_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Comma-separated list of hosts that bypass the proxy on EDA containers
-        displayName: No Proxy
-        path: no_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Service Account Annotations
         path: service_account_annotations
         x-descriptors:

--- a/config/samples/eda_v1alpha1_eda.yaml
+++ b/config/samples/eda_v1alpha1_eda.yaml
@@ -45,7 +45,3 @@ spec:
     storage_requirements:
       requests:
         storage: 20Gi
-  # HTTP proxy settings (optional)
-  # http_proxy: "http://proxy.example.com:3128"
-  # https_proxy: "http://proxy.example.com:3128"
-  # no_proxy: "localhost,127.0.0.1,.cluster.local"

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -149,9 +149,7 @@ hostname: ''
 bundle_cacert_secret: ''
 
 # Proxy environment variables for EDA containers.
-# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
-# proxy object). Set these fields in the CR spec to override the inherited values
-# per instance.
+# Values are inherited from the operator pod environment.
 http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
 https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
 no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"


### PR DESCRIPTION
## Summary

- Removes `http_proxy`, `https_proxy`, and `no_proxy` from the CRD spec
  and CSV specDescriptors
- Proxy configuration is injected into the operator pod environment and
  propagated to containers via the existing ConfigMap mechanism

## Test plan

- [x] Verify operator reconciles cleanly with no failed tasks
- [x] Verify proxy environment variables are not exposed in CRD spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Database specification restructured with idle_deployment field moved to primary spec level
  * HTTP proxy, HTTPS proxy, and no proxy configuration removed from database settings
  * Updated sample configurations and operator manifests to reflect new database structure
  * Simplified proxy configuration documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->