### PR TITLE
fix(nginx): mount bundle_cacert volumes in nginx sidecar containers

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -446,6 +446,14 @@ spec:
             mountPath: /var/cache/nginx
           - name: nginx-run
             mountPath: /var/run
+{% if bundle_ca_crt %}
+          - name: "ca-trust-extracted"
+            mountPath: "/etc/pki/ca-trust/extracted"
+          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            subPath: bundle-ca.crt
+            readOnly: true
+{% endif %}
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}

--- a/roles/eda/templates/eda-event-stream.deployment.yaml.j2
+++ b/roles/eda/templates/eda-event-stream.deployment.yaml.j2
@@ -235,6 +235,14 @@ spec:
             mountPath: /var/cache/nginx
           - name: nginx-run
             mountPath: /var/run
+{% if bundle_ca_crt %}
+          - name: "ca-trust-extracted"
+            mountPath: "/etc/pki/ca-trust/extracted"
+          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            subPath: bundle-ca.crt
+            readOnly: true
+{% endif %}
       restartPolicy: Always
       volumes:
         - name: '{{ ansible_operator_meta.name }}-nginx-event-stream-conf'


### PR DESCRIPTION
## Summary
- Follow-up to PR #342: mount `ca-trust-extracted` and `bundle-cacert` volumes in the nginx sidecar containers within both the API and event-stream deployments when `bundle_cacert_secret` is configured
- Ensures the custom CA trust store is consistently available across all containers in the pod, matching daphne, gunicorn, and the worker containers

## Test plan
- [ ] Deploy EDA with `bundle_cacert_secret` set and verify the nginx container has the CA trust mounts
- [ ] Verify existing CI tests pass


Made with [Cursor](https://cursor.com)

AAP-75755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced deployment configurations with support for custom CA certificate management and secure connections. When enabled, custom certificate authority bundles are automatically mounted and trusted within API and event stream service containers, facilitating secure HTTPS connections to external services, internal endpoints, and third-party integrations that use private, custom, or self-signed SSL/TLS certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->