### PR TITLE
chore: add .cve-fix/examples.md guidance for CVE fixer workflow

### DIFF
--- a/.cve-fix/examples.md
+++ b/.cve-fix/examples.md
@@ -1,0 +1,22 @@
+<!-- last-analyzed: 2026-05-19 | cve-merged: 0 -->
+<!-- Insufficient PR history for full pattern extraction.
+     Update with /guidance.update after more CVE fixes are merged. -->
+
+## Titles
+- No CVE fix PRs found — use conventional commit format: `fix(deps): <description> (<CVE-ID>)`
+
+## Branches
+- No CVE fix PRs found — use: `fix/cve-YYYY-NNNNN-<package>`
+
+## Files
+- Likely Go-based operator — expect `go.mod`, `go.sum`, and possibly vendor directory changes
+
+## Co-upgrades
+- No data available
+
+## PR Description
+- Include CVE ID, severity, CVSS score
+- Reference Jira issue
+
+## Don'ts
+- No data available


### PR DESCRIPTION
Adds `.cve-fix/examples.md` so the CVE fixer workflow knows how to
create fix PRs matching this repo's conventions (branch naming, files that
change together, co-upgrades, etc.).

Generated by `/onboard` — minimal guidance due to no CVE PR history.
Run `/guidance.update` after more CVE fixes are merged to improve.

🤖 Generated by /onboard