### PR TITLE
fix(deps): upgrade ansible-operator v1.40.0 → v1.42.2 (CVE-2026-33186)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ kustomization.yaml
 *.swo
 *~
 .vscode/
+/.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.40.0
+FROM quay.io/operator-framework/ansible-operator:v1.42.2
 
 ARG DEFAULT_EDA_VERSION
 ARG DEFAULT_EDA_UI_VERSION

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.40.0
+OPERATOR_SDK_VERSION ?= v1.42.2
 CONTAINER_TOOL ?= podman
 
 # Image URL to use all building/pushing image targets


### PR DESCRIPTION
## Summary
- **CVE-2026-33186**: gRPC-Go authorization bypass due to improper HTTP/2
  `:path` validation (CVSS 9.1). Fixed in grpc-go v1.79.3.
- Upgrades `ansible-operator` base image and `OPERATOR_SDK_VERSION` from
  v1.40.0 to v1.42.2, which ships `google.golang.org/grpc@v1.79.3`.
- Upstream fix only. The downstream RHEL image
(`ansible-automation-platform-26/eda-controller-rhel9-operator`) is built
from `openshift/ansible-operator-plugins`, which is still at
`google.golang.org/grpc@v1.75.1`. The downstream image remains vulnerable
until that fork bumps gRPC-Go to >= v1.79.3 and the base image is rebuilt.

Tracked in: https://redhat.atlassian.net/browse/AAP-76149

## Changes
| File | Change |
|---|---|
| `Dockerfile:1` | Base image `v1.40.0` → `v1.42.2` |
| `Makefile:51` | `OPERATOR_SDK_VERSION` `v1.40.0` → `v1.42.2` |

## Verification
Fix confirmed by pulling `ansible-operator:v1.42.2` and inspecting the
embedded Go module version: 
- strings ansible-operator | grep "google.golang.org/grpc@"
- google.golang.org/grpc@v1.79.3

## Test Plan
- [ ] `make docker-build` succeeds
- [ ] Operator deploys and reconciles in test cluster
- [ ] Existing molecule tests pass

Ref: [AAP-75792](https://redhat.atlassian.net/browse/AAP-75792)
Assisted by: Claude Opus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated operator framework base image and operator SDK toolkit from v1.40.0 to v1.42.2 for improved stability and features
  * Refreshed build environment configuration to use updated toolkit versions
  * Added Python virtual environment directory to development ignore list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->