### PR TITLE
remove: Remove deprecated reference to manager_auth_proxy_patch.yaml

### DIFF
--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -20,4 +20,3 @@ images:
 patches:
 - path: manager_image.yaml
 - path: debug_logs_patch.yaml
-- path: ../default/manager_auth_proxy_patch.yaml


### PR DESCRIPTION
## Summary

Removes a stale reference to `../default/manager_auth_proxy_patch.yaml` in `config/testing/kustomization.yaml`.

This file was deleted in #323 but the reference was left behind, causing `kustomize build` to fail for anyone using the `config/testing` directory.

Closes #262

## Changes

- `config/testing/kustomization.yaml`: removed path entry pointing to deleted file `../default/manager_auth_proxy_patch.yaml`

## Note

`make lint` was already failing before this change on `roles/postgres/` and `roles/restore/`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing environment configuration to switch manager image reference and enable more verbose debug logging during tests.
  * Removed an obsolete proxy patch to streamline test setup and improve configuration consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->