### PR TITLE
ci: Add workflow to validate all kustomize builds

### DIFF
--- a/.github/workflows/validate-kustomize.yml
+++ b/.github/workflows/validate-kustomize.yml
@@ -1,0 +1,37 @@
+---
+name: Validate Kustomize
+
+on:
+  pull_request:
+
+jobs:
+  validate-kustomize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install kustomize
+        run: |
+          set -euxo pipefail
+          make kustomize
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+
+      - name: Validate all kustomization.yaml files
+        run: |
+          set -euxo pipefail
+          failed=0
+          while IFS= read -r f; do
+            dir=$(dirname "$f")
+            echo "--- Validating $dir ---"
+            if ! kustomize build "$dir" > /dev/null; then
+              echo "::error file=$f::kustomize build failed for $dir"
+              failed=1
+            else
+              echo "✓ $dir OK"
+            fi
+          done < <(find . -name "kustomization.yaml" -not -path "*/vendor/*")
+          exit $failed


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow to validate all `kustomization.yaml` files in the repository on every pull request.

This was suggested in #350, where a stale reference to a deleted file (`../default/manager_auth_proxy_patch.yaml`) went undetected until manually tested. A kustomize validation step was suggested to solve this problem

## What it does

- Finds all `kustomization.yaml` files in the repository (excluding `vendor/`)
- Runs `kustomize build` on each one to ensure all referenced files exist and the YAML is valid
- Reports all failures at once instead of stopping at the first error

## Testing

Validated locally and in CI on a test [PR](https://github.com/Francisco-xiq/eda-server-operator/pull/3) that intentionally reintroduced the broken reference, the workflow correctly failed with a clear error message pointing to the problematic file. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated pull-request CI check that validates kustomize configurations across the repository (skips vendored paths). It runs per-directory build validations on pull requests, reports per-directory results, annotates failing manifests inline, and fails the PR check if any validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->