### PR TITLE
deprecate: mark postgres_keep_pvc_after_upgrade deprecated and remove implementation

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -2389,7 +2389,7 @@ spec:
                       Default: "prefer"'
                     type: string
                   postgres_keep_pvc_after_upgrade:
-                    description: Specify whether or not to keep the old PVC after PostgreSQL upgrades
+                    description: "(Deprecated) Specify whether or not to keep the old PVC after PostgreSQL upgrades"
                     type: boolean
                   storage_requirements:
                     description: Storage requirements for the PostgreSQL container

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -359,11 +359,6 @@ spec:
         path: database.priority_class
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Should PostgreSQL data for managed databases be kept after upgrades?
-        path: database.postgres_keep_pvc_after_upgrade
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: API Image
         path: image
         x-descriptors:

--- a/docs/upgrade/upgrading.md
+++ b/docs/upgrade/upgrading.md
@@ -66,15 +66,3 @@ Starting with this version, the EDA operator **no longer deploys or uses Redis**
 > **Note:** The `redis` fields remain in the CRD schema for backward compatibility but are marked as deprecated. They will be removed in a future `apiVersion`.
 
 For more details, see the [Redis Deprecation Notice](../user-guide/redis-configuration.md).
-
-#### PostgreSQL Upgrade Considerations
-
-If there is a PostgreSQL major version upgrade, after the data directory on the PVC is migrated to the new version, the old PVC is kept by default.
-This provides the ability to roll back if needed, but can take up extra storage space in your cluster unnecessarily. By default, the postgres pvc from the previous version will remain unless you manually remove it, or have the `database.postgres_keep_pvc_after_upgrade` parameter set to false. You can configure it to be deleted automatically
-after a successful upgrade by setting the following variable on the EDA spec.
-
-```yaml
-  spec:
-    database:
-        postgres_keep_pvc_after_upgrade: false
-```

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -41,7 +41,6 @@ _database:
   tolerations: []
   postgres_extra_args: ''  # Deprecated
   postgres_extra_settings: []  # Define postgresql.conf configurations
-  postgres_keep_pvc_after_upgrade: true  # Specify whether or not to keep the old PVC after PostgreSQL upgrades
   postgres_data_volume_init: false
   postgres_init_container_commands: |
     chown 26:0 /var/lib/pgsql/data

--- a/roles/postgres/tasks/upgrade_postgres.yml
+++ b/roles/postgres/tasks/upgrade_postgres.yml
@@ -168,14 +168,3 @@
   loop:
     - "{{ ansible_operator_meta.name }}-postgres-13"
 
-- name: Remove old persistent volume claim
-  k8s:
-    kind: PersistentVolumeClaim
-    api_version: v1
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    name: "{{ item }}"
-    state: absent
-  loop:
-    - "postgres-{{ ansible_operator_meta.name }}-postgres-13-0"
-    - "postgres-13-{{ ansible_operator_meta.name }}-postgres-13-0"
-  when: not combined_database.postgres_keep_pvc_after_upgrade | bool


### PR DESCRIPTION
## Summary

Deprecates `postgres_keep_pvc_after_upgrade` in the CRD and removes the
implementation. The field has no effect going forward; old Postgres PVCs are
always preserved after upgrade, consistent with standard behavior across
platform operators.

- Mark field as `(Deprecated)` in CRD description
- Remove PVC deletion task from `upgrade_postgres.yml`
- Remove CSV specDescriptor entry
- Remove role default
- Remove upgrading.md usage example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Deprecations**
  * The `postgres_keep_pvc_after_upgrade` configuration field is now marked as deprecated.

* **Changes**
  * PostgreSQL upgrade process no longer automatically removes old persistent volume claims after upgrades.
  * Updated documentation clarifying deprecated features and backward compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->