### PR TITLE
Allow skipping PostgreSQL database backup/restore

### DIFF
--- a/config/crd/bases/eda.ansible.com_edabackups.yaml
+++ b/config/crd/bases/eda.ansible.com_edabackups.yaml
@@ -100,6 +100,10 @@ spec:
               postgres_image_version:
                 description: PostgreSQL container image version to use
                 type: string
+              postgres_skip_data:
+                description: Skip PostgreSQL database dump.
+                type: boolean
+                default: false
               no_log:
                 description: Configure no_log for no_log tasks
                 type: boolean
@@ -135,3 +139,6 @@ spec:
               backupClaim:
                 description: Backup persistent volume claim
                 type: string
+              backupPostgres:
+                description: Backup PostgreSQL data
+                type: boolean

--- a/config/crd/bases/eda.ansible.com_edarestores.yaml
+++ b/config/crd/bases/eda.ansible.com_edarestores.yaml
@@ -95,6 +95,10 @@ spec:
               postgres_image_version:
                 description: PostgreSQL container image version to use
                 type: string
+              postgres_skip_data:
+                description: Skip PostgreSQL database restore.
+                type: boolean
+                default: false
               spec_overrides:
                 description: Overrides for the EDA spec
                 type: object
@@ -130,4 +134,7 @@ spec:
                 type: array
               restoreComplete:
                 description: Restore process complete
+                type: boolean
+              restorePostgres:
+                description: Restore PostgreSQL data
                 type: boolean

--- a/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/eda-server-operator.clusterserviceversion.yaml
@@ -59,6 +59,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Skip PostgreSQL database dump
+        path: postgres_skip_data
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Scale down deployments to put EDA into an idle state
         displayName: Idle EDA
         path: idle_deployment
@@ -185,6 +190,11 @@ spec:
         path: postgres_image_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Skip PostgreSQL database restore
+        path: postgres_skip_data
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: EDA Spec Overrides
         path: spec_overrides
         x-descriptors:

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -37,6 +37,9 @@ pg_dump_suffix: ''
 # Enable compression for database dumps (pg_dump -F custom built-in compression)
 use_db_compression: true
 
+# Skip PostgreSQL database dump
+postgres_skip_data: false
+
 # Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
 set_self_labels: true
 ...

--- a/roles/backup/tasks/creation.yml
+++ b/roles/backup/tasks/creation.yml
@@ -29,7 +29,10 @@
 - block:
     - include_tasks: init.yml
 
+    - include_tasks: set_database_config.yml
+
     - include_tasks: postgres.yml
+      when: not postgres_skip_data | bool or eda_postgres_type == 'managed'
 
     - include_tasks: eda-cro.yml
 

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -93,3 +93,18 @@
     name: "{{ deployment_name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
   register: this_eda
+
+- name: Determine the timestamp for the backup once for all nodes
+  set_fact:
+    now: '{{ lookup("pipe", "date +%F-%T") }}'
+
+- name: Set backup directory name
+  set_fact:
+    backup_dir: "/backups/eda-openshift-backup-{{ now }}"
+
+- name: Create directory for backup
+  k8s_exec:
+    namespace: "{{ backup_pvc_namespace }}"
+    pod: "{{ ansible_operator_meta.name }}-db-management"
+    command: >-
+      mkdir -p {{ backup_dir }}

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -1,28 +1,4 @@
 ---
-
-- name: Get PostgreSQL configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ ansible_operator_meta.namespace }}'
-    name: "{{ this_eda['resources'][0]['status']['databaseConfigurationSecret'] }}"
-  register: pg_config
-  no_log: "{{ no_log }}"
-
-- name: Fail if postgres configuration secret status does not exist
-  fail:
-    msg: "The databaseConfigurationSecret status is not set on the EDA object yet or the secret has been deleted."
-  when: not pg_config | default([]) | length
-
-- name: Store Database Configuration
-  set_fact:
-    eda_postgres_user: "{{ pg_config['resources'][0]['data']['username'] | b64decode }}"
-    eda_postgres_pass: "{{ pg_config['resources'][0]['data']['password'] | b64decode }}"
-    eda_postgres_database: "{{ pg_config['resources'][0]['data']['database'] | b64decode }}"
-    eda_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
-    eda_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
-    eda_postgres_type: "{{ pg_config['resources'][0]['data']['type'] | default('unmanaged'|b64encode) | b64decode }}"
-  no_log: "{{ no_log }}"
-
 - block:
     - name: Delete pod to reload a resource configuration
       set_fact:
@@ -47,21 +23,6 @@
       set_fact:
         postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
   when: eda_postgres_type == 'managed'
-
-- name: Determine the timestamp for the backup once for all nodes
-  set_fact:
-    now: '{{ lookup("pipe", "date +%F-%T") }}'
-
-- name: Set backup directory name
-  set_fact:
-    backup_dir: "/backups/eda-openshift-backup-{{ now }}"
-
-- name: Create directory for backup
-  k8s_exec:
-    namespace: "{{ backup_pvc_namespace }}"
-    pod: "{{ ansible_operator_meta.name }}-db-management"
-    command: >-
-      mkdir -p {{ backup_dir }}
 
 - name: Precreate file for database dump
   k8s_exec:

--- a/roles/backup/tasks/set_database_config.yml
+++ b/roles/backup/tasks/set_database_config.yml
@@ -1,0 +1,24 @@
+---
+- name: Get PostgreSQL configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: "{{ this_eda['resources'][0]['status']['databaseConfigurationSecret'] }}"
+  register: pg_config
+  no_log: "{{ no_log }}"
+
+- name: Fail if postgres configuration secret status does not exist
+  fail:
+    msg: "The databaseConfigurationSecret status is not set on the EDA object yet or the secret has been deleted."
+  when: not pg_config | default([]) | length
+
+- name: Store Database Configuration
+  set_fact:
+    eda_postgres_user: "{{ pg_config['resources'][0]['data']['username'] | b64decode }}"
+    eda_postgres_pass: "{{ pg_config['resources'][0]['data']['password'] | b64decode }}"
+    eda_postgres_database: "{{ pg_config['resources'][0]['data']['database'] | b64decode }}"
+    eda_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
+    eda_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
+    eda_postgres_type: "{{ pg_config['resources'][0]['data']['type'] | default('unmanaged'|b64encode) | b64decode }}"
+  no_log: "{{ no_log }}"
+...

--- a/roles/backup/tasks/update_status.yml
+++ b/roles/backup/tasks/update_status.yml
@@ -10,4 +10,5 @@
     status:
       backupDirectory: "{{ backup_dir }}"
       backupClaim: "{{ backup_pvc }}"
+      backupPostgres: "{{ not postgres_skip_data | bool or eda_postgres_type == 'managed' }}"
   when: backup_complete

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -32,4 +32,7 @@ set_self_labels: true
 spec_overrides: {}
 
 force_drop_db: false
+
+# Skip PostgreSQL database restore
+postgres_skip_data: false
 ...

--- a/roles/restore/tasks/check_postgres_backup.yml
+++ b/roles/restore/tasks/check_postgres_backup.yml
@@ -1,0 +1,18 @@
+---
+- name: Check the PostgreSQL database backup file
+  kubernetes.core.k8s_exec:
+    namespace: "{{ backup_pvc_namespace }}"
+    pod: "{{ ansible_operator_meta.name }}-db-management"
+    command: |
+      stat {{ backup_dir }}/eda.db
+  changed_when: false
+  failed_when: false
+  register: _eda_db
+
+- name: Fail if the database backup file is missing and postgres_skip_data not enabled
+  ansible.builtin.assert:
+    that:
+      - postgres_skip_data | bool
+    fail_msg: "postgres_skip_data needs to be set to true when the database dump does not exist"
+  when: _eda_db.rc | bool
+...

--- a/roles/restore/tasks/main.yml
+++ b/roles/restore/tasks/main.yml
@@ -35,7 +35,13 @@
 
     - include_tasks: deploy_eda.yml
 
+    - include_tasks: set_database_config.yml
+
+    - include_tasks: check_postgres_backup.yml
+      when: eda_postgres_type == 'unmanaged'
+
     - include_tasks: postgres.yml
+      when: not postgres_skip_data | bool or eda_postgres_type == 'managed'
 
     - name: Set flag signifying this restore was successful
       set_fact:

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -1,27 +1,4 @@
 ---
-
-- name: Set Postgres Configuration Secret name
-  set_fact:
-    database_secret: "{{ spec['database']['database_secret'] }}"
-
-- name: Check for specified PostgreSQL configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ ansible_operator_meta.namespace }}'
-    name: '{{ database_secret }}'
-  register: pg_config
-  no_log: "{{ no_log }}"
-
-- name: Store Database Configuration
-  set_fact:
-    eda_postgres_user: "{{ pg_config['resources'][0]['data']['username'] | b64decode }}"
-    eda_postgres_pass: "{{ pg_config['resources'][0]['data']['password'] | b64decode }}"
-    eda_postgres_database: "{{ pg_config['resources'][0]['data']['database'] | b64decode }}"
-    eda_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
-    eda_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
-    eda_postgres_type: "{{ pg_config['resources'][0]['data']['type'] | b64decode | default('unmanaged') }}"
-  no_log: "{{ no_log }}"
-
 - name: Set Default label selector for custom resource generated postgres
   set_fact:
     postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ supported_pg_version }}-{{ deployment_name }}"

--- a/roles/restore/tasks/set_database_config.yml
+++ b/roles/restore/tasks/set_database_config.yml
@@ -1,0 +1,23 @@
+---
+- name: Set Postgres Configuration Secret name
+  set_fact:
+    database_secret: "{{ spec['database']['database_secret'] }}"
+
+- name: Check for specified PostgreSQL configuration
+  k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ database_secret }}'
+  register: pg_config
+  no_log: "{{ no_log }}"
+
+- name: Store Database Configuration
+  set_fact:
+    eda_postgres_user: "{{ pg_config['resources'][0]['data']['username'] | b64decode }}"
+    eda_postgres_pass: "{{ pg_config['resources'][0]['data']['password'] | b64decode }}"
+    eda_postgres_database: "{{ pg_config['resources'][0]['data']['database'] | b64decode }}"
+    eda_postgres_port: "{{ pg_config['resources'][0]['data']['port'] | b64decode }}"
+    eda_postgres_host: "{{ pg_config['resources'][0]['data']['host'] | b64decode }}"
+    eda_postgres_type: "{{ pg_config['resources'][0]['data']['type'] | b64decode | default('unmanaged') }}"
+  no_log: "{{ no_log }}"
+...

--- a/roles/restore/tasks/update_status.yml
+++ b/roles/restore/tasks/update_status.yml
@@ -8,4 +8,5 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
       restoreComplete: true
+      restorePostgres: "{{ not postgres_skip_data | bool or eda_postgres_type == 'managed' }}"
   when: eda_restore_complete is defined


### PR DESCRIPTION
This allows one to skip the PostgreSQL database dump/restore during via the EDABackup and EDARestore CRDs on external database configuration.

A new parameter called `postgres_skip_data` is introduced (defaults to false for backward compatibility) but can be turn on to skip the pg_dump and pg_restore parts.

At restore time, if no database dump file is found in the backup then the `postgres_skip_data` parameter needs to be explicitely set to true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `postgres_skip_data` option to skip PostgreSQL database dump/restore data in both backup and restore operations
  * Added `.status.backupPostgres` and `.status.restorePostgres` fields to report whether PostgreSQL data handling was performed
  * Added restore validation that checks for the PostgreSQL backup file and requires `postgres_skip_data` when it’s missing
* **Improvements**
  * Improved PostgreSQL connection handling by sourcing configuration from the referenced Secret during backup and restore
<!-- end of auto-generated comment: release notes by coderabbit.ai -->