### PR TITLE
ci: Reduce operator verbosity to 2

### DIFF
--- a/.ci/eda_v1alpha1_eda.default.ci.yaml
+++ b/.ci/eda_v1alpha1_eda.default.ci.yaml
@@ -3,7 +3,7 @@ kind: EDA
 metadata:
   name: eda-demo
   annotations:
-    "ansible.sdk.operatorframework.io/verbosity": "5"
+    "ansible.sdk.operatorframework.io/verbosity": "2"
 spec:
   no_log: false
   automation_server_url: http://foo.bar

--- a/.ci/eda_v1alpha1_eda.event_persistence.ci.yaml
+++ b/.ci/eda_v1alpha1_eda.event_persistence.ci.yaml
@@ -3,7 +3,7 @@ kind: EDA
 metadata:
   name: eda-demo
   annotations:
-    "ansible.sdk.operatorframework.io/verbosity": "5"
+    "ansible.sdk.operatorframework.io/verbosity": "2"
 spec:
   no_log: false
   automation_server_url: http://foo.bar

--- a/.ci/eda_v1alpha1_eda.externaldb.ci.yaml
+++ b/.ci/eda_v1alpha1_eda.externaldb.ci.yaml
@@ -3,7 +3,7 @@ kind: EDA
 metadata:
   name: eda-demo
   annotations:
-    "ansible.sdk.operatorframework.io/verbosity": "5"
+    "ansible.sdk.operatorframework.io/verbosity": "2"
 spec:
   no_log: false
   automation_server_url: http://foo.bar

--- a/.ci/eda_v1alpha1_eda.ingress.ci.yaml
+++ b/.ci/eda_v1alpha1_eda.ingress.ci.yaml
@@ -3,7 +3,7 @@ kind: EDA
 metadata:
   name: eda-demo
   annotations:
-    "ansible.sdk.operatorframework.io/verbosity": "5"
+    "ansible.sdk.operatorframework.io/verbosity": "2"
 spec:
   no_log: false
   automation_server_url: http://foo.bar

--- a/.ci/eda_v1alpha1_edabackup.ci.yaml
+++ b/.ci/eda_v1alpha1_edabackup.ci.yaml
@@ -3,7 +3,7 @@ kind: EDABackup
 metadata:
   name: eda-demo-backup
   annotations:
-    "ansible.sdk.operatorframework.io/verbosity": "5"
+    "ansible.sdk.operatorframework.io/verbosity": "2"
 spec:
   no_log: false
   deployment_name: eda-demo

--- a/.ci/eda_v1alpha1_edarestore.ci.yaml
+++ b/.ci/eda_v1alpha1_edarestore.ci.yaml
@@ -3,7 +3,7 @@ kind: EDARestore
 metadata:
   name: eda-demo-restore
   annotations:
-    "ansible.sdk.operatorframework.io/verbosity": "5"
+    "ansible.sdk.operatorframework.io/verbosity": "2"
 spec:
   no_log: false
   deployment_name: eda-demo


### PR DESCRIPTION
Using verbosity 5 is a little bit too much even for debugging. Let's reduce it to 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging configuration settings across multiple automation resource definitions to adjust verbosity output levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->