### PR TITLE
Set WORKER_KIND to websocket on daphne

### DIFF
--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -411,6 +411,8 @@ spec:
             secretKeyRef:
               name: '{{ db_fields_encryption_secret_name }}'
               key: secret_key
+        - name: EDA_WORKER_KIND
+          value: "websocket"
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}


### PR DESCRIPTION
This adds the `EDA_WORKER_KIND` environment variable to the EDA daphne container so the authentication classes loaded by the EDA application are set to a different value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated WebSocket worker configuration to enhance real-time communication handling and connectivity reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->