### PR TITLE
bump operator-sdk version to v1.42.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.40.0
+FROM quay.io/operator-framework/ansible-operator:v1.42.2
 
 ARG DEFAULT_EDA_VERSION
 ARG DEFAULT_EDA_UI_VERSION

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.40.0
+OPERATOR_SDK_VERSION ?= v1.42.2
 CONTAINER_TOOL ?= podman
 
 # Image URL to use all building/pushing image targets


### PR DESCRIPTION
Bump operator-sdk from v1.40.0 to v1.42.2. Updates `OPERATOR_SDK_VERSION` in Makefile and the base image in Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the operator-framework base image from v1.40.0 to v1.42.2 for improved stability and compatibility.
  * Bumped the Makefile’s operator SDK version from v1.40.0 to v1.42.2, ensuring build and validation steps download the newer operator-sdk release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->