### PR TITLE
Add activation_job_namespace for workload isolation

### DIFF
--- a/config/crd/bases/eda.ansible.com_edas.yaml
+++ b/config/crd/bases/eda.ansible.com_edas.yaml
@@ -1476,6 +1476,9 @@ spec:
                       type: object
                     type: array
                 type: object
+              activation_job_namespace:
+                description: Namespace where activation job pods will run. Creates the namespace and grants required permissions automatically.
+                type: string
               activation_worker:
                 description: Defines desired state of eda-activation-worker resources
                 properties:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,6 +4,13 @@ kind: Role
 metadata:
   name: eda-manager-role
 rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
   ##
   ## Base operator rules
   ##

--- a/roles/common/templates/service_account.yaml.j2
+++ b/roles/common/templates/service_account.yaml.j2
@@ -26,9 +26,8 @@ rules:
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-{% else %}
-- apiGroups: ["batch", "extensions"]
-  resources: ["jobs"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {% endif %}
 

--- a/roles/common/templates/service_account.yaml.j2
+++ b/roles/common/templates/service_account.yaml.j2
@@ -19,15 +19,18 @@ metadata:
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 rules:
-- apiGroups: [""] # "" indicates the core API group
+{% if not activation_job_namespace %}
+- apiGroups: [""]
   resources: ["pods", "pods/log", "jobs", "secrets", "services"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: ["networking.k8s.io"]
-  resources: ["ingresses"]
+{% else %}
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{% endif %}
 
 ---
 kind: RoleBinding
@@ -44,3 +47,51 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: '{{ ansible_operator_meta.name }}'
+
+{% if activation_job_namespace %}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: '{{ activation_job_namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: '{{ ansible_operator_meta.name }}-job-execution'
+  namespace: '{{ activation_job_namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: '{{ ansible_operator_meta.name }}-job-execution'
+  namespace: '{{ activation_job_namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+subjects:
+- kind: ServiceAccount
+  name: '{{ ansible_operator_meta.name }}'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ ansible_operator_meta.name }}-job-execution'
+{% endif %}

--- a/roles/eda/defaults/main.yml
+++ b/roles/eda/defaults/main.yml
@@ -26,6 +26,8 @@ _image_web_version: "{{ lookup('env', 'DEFAULT_EDA_UI_VERSION') or 'main' }}"
 #     kubernetes.io/arch: amd64
 #     kubernetes.io/os: linux
 
+activation_job_namespace: ''
+
 websocket_ssl_verify: false
 
 api: {}

--- a/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
+++ b/roles/eda/templates/eda-activation-worker.deployment.yaml.j2
@@ -251,6 +251,10 @@ spec:
         - name: EDA_EVENT_PERSISTENCE_PGSSLMODE
           value: '{{ event_persistence_postgres_sslmode }}'
 {% endif %}
+{% if activation_job_namespace %}
+        - name: EDA_ACTIVATION_JOB_NAMESPACE
+          value: '{{ activation_job_namespace }}'
+{% endif %}
 {% if combined_activation_worker.resource_requirements is defined %}
         resources: {{ combined_activation_worker.resource_requirements }}
 {% endif %}


### PR DESCRIPTION
## Summary

- Adds an optional `activation_job_namespace` field to the EDA CR that isolates activation job pods in a dedicated namespace
- When set, pod/job/secret/service permissions are moved from the EDA namespace Role to a new Role in the dedicated namespace, following the principle of least privilege
- The operator automatically creates the namespace, Role, and RoleBinding, and passes `EDA_ACTIVATION_JOB_NAMESPACE` to the activation-worker container
- When not set, behavior is unchanged (fully backwards compatible)

Follows the same pattern as [awx-operator#2122](https://github.com/ansible/awx-operator/pull/2122).

## Changes

| File | Change |
|------|--------|
| `config/crd/bases/eda.ansible.com_edas.yaml` | Add `activation_job_namespace` string field to CRD spec |
| `roles/eda/defaults/main.yml` | Add `activation_job_namespace: ''` default |
| `roles/common/templates/service_account.yaml.j2` | Conditionally scope RBAC: remove pod/job/secret/service/ingress perms from EDA namespace when set; create Namespace + Role + RoleBinding in dedicated namespace |
| `config/rbac/role.yaml` | Grant operator `namespaces` (get, create) permission |
| `roles/eda/templates/eda-activation-worker.deployment.yaml.j2` | Pass `EDA_ACTIVATION_JOB_NAMESPACE` env var to activation-worker when set |

## Test plan

- [ ] Deploy EDA **without** `activation_job_namespace` set — verify existing behavior is unchanged
- [ ] Deploy EDA **with** `activation_job_namespace: eda-jobs` — verify:
  - [ ] Namespace `eda-jobs` is created
  - [ ] Role and RoleBinding exist in `eda-jobs` namespace with correct permissions
  - [ ] EDA namespace Role no longer has pod/job/secret/service permissions
  - [ ] Activation worker pod has `EDA_ACTIVATION_JOB_NAMESPACE=eda-jobs` env var
  - [ ] Activation jobs run in the `eda-jobs` namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `spec.activation_job_namespace` to specify the namespace where activation job pods run.
  * When set, activation job namespace permissions are created/granted automatically.
  * The activation worker now receives `EDA_ACTIVATION_JOB_NAMESPACE` when `activation_job_namespace` is provided.

* **RBAC & Security**
  * Updated RBAC to conditionally scope activation job permissions based on `activation_job_namespace`.
  * Added permissions needed to create/access namespaces as part of the activation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->