### PR TITLE
chore: sync Makefile standardization, update operator-sdk to v1.42.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.42.2
+FROM quay.io/operator-framework/ansible-operator:v1.42.3
 
 ARG DEFAULT_EDA_VERSION
 ARG DEFAULT_EDA_UI_VERSION

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.42.2
+OPERATOR_SDK_VERSION ?= v1.42.3
 CONTAINER_TOOL ?= podman
 
 # Image URL to use all building/pushing image targets

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -357,9 +357,9 @@ dev-build: ## Build dev image (auto-detects arch of connected cluster, cross-com
 patch-pull-policy: ## Patch imagePullPolicy in manager config (default: Always, override with IMAGE_PULL_POLICY)
 	@_POLICY="$(if $(IMAGE_PULL_POLICY),$(IMAGE_PULL_POLICY),Always)"; \
 	for file in config/manager/manager.yaml; do \
-		if [ -f "$$file" ] && grep -q 'imagePullPolicy: IfNotPresent' "$$file"; then \
+		if [ -f "$$file" ] && grep -q 'imagePullPolicy:' "$$file"; then \
 			echo "Patching imagePullPolicy to $$_POLICY in $$file"; \
-			$(_SED_I) "s|imagePullPolicy: IfNotPresent|imagePullPolicy: $$_POLICY|g" "$$file"; \
+			$(_SED_I) "s|imagePullPolicy: .*|imagePullPolicy: $$_POLICY|g" "$$file"; \
 		fi; \
 	done
 


### PR DESCRIPTION
## Summary

Sync Makefile standardization from aap-gateway-operator and update operator-sdk to v1.42.3.

v1.42.3 is a dependency-only release (go-git, containerd, otel, UBI 9.7→9.8). No breaking changes.

[Release notes](https://github.com/operator-framework/operator-sdk/releases/tag/v1.42.3)

### Files synced
- Makefile
- makefiles/common.mk
- Dockerfile (FROM line version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bundled operator tooling and base image to the latest patch version.
  - Improved image pull policy handling so it applies more reliably to manager configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->