### PR TITLE
fix: remove unnecessary chmod/chown from backup postgres task

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -31,13 +31,6 @@
     command: >-
       touch {{ backup_dir }}/eda.db
 
-- name: Set permissions on file for database dump
-  k8s_exec:
-    namespace: "{{ backup_pvc_namespace }}"
-    pod: "{{ ansible_operator_meta.name }}-db-management"
-    command: >-
-      bash -c "chmod 660 {{ backup_dir }}/eda.db && chown :root {{ backup_dir }}/eda.db"
-
 - name: Set full resolvable host name for postgres pod
   set_fact:
     resolvable_db_host: '{{ (eda_postgres_type == "managed") | ternary(eda_postgres_host + "." + ansible_operator_meta.namespace + ".svc.cluster.local", eda_postgres_host) }}'  # yamllint disable-line rule:line-length


### PR DESCRIPTION
##### SUMMARY
Remove the unnecessary `chmod 660` and `chown :root` from the backup
postgres task. This step fails on storage backends that enforce POSIX
identity (e.g., AWS EFS with access points), breaking backup entirely.

The step is unnecessary - the restore path reads the dump file without
ownership or permission checks, and `pg_dump` overwrites any permissions
set on the precreated file.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### STEPS TO REPRODUCE AND EXTRA INFO
1. Configure EDA with an EFS-backed StorageClass using access points
   with enforced `uid`/`gid`
2. Create an EDA Backup CR
3. Observe failure: `chown: changing group of '/backups/.../eda.db': Operation not permitted`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database backup file preparation by simplifying dump-file creation and avoiding redundant permission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->