### PR TITLE
fix: [AAP-84188] add a finalizer playbook to the EDA CR

### DIFF
--- a/playbooks/eda_finalizer.yml
+++ b/playbooks/eda_finalizer.yml
@@ -1,0 +1,14 @@
+---
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - kubernetes.core
+  tasks:
+    - name: Delete all activation Jobs
+      k8s:
+        api_version: batch/v1
+        kind: Job
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        state: absent
+        label_selectors:
+          - "app=eda"

--- a/watches.yaml
+++ b/watches.yaml
@@ -3,6 +3,9 @@
   group: eda.ansible.com
   kind: EDA
   playbook: playbooks/eda.yml
+  finalizer:
+    name: eda.ansible.com/finalizer
+    playbook: playbooks/eda_finalizer.yml
 
 - version: v1alpha1
   group: eda.ansible.com


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-84188

Rulebook Activation pods should be cleaned up when the EDA CR is deleted (i.e, an uninstall). We now add a simple playbook to take care of deleting the Jobs that the activation workers create for the rulebook activations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of EDA-related Kubernetes Jobs when an EDA resource is deleted.
  * Registered an EDA finalizer to ensure associated Jobs are removed before resource deletion completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->