### PR TITLE
fix: preserve backup_dir on finalizer path for clean_backup_on_delete

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -97,10 +97,12 @@
 - name: Determine the timestamp for the backup once for all nodes
   set_fact:
     now: '{{ lookup("pipe", "date +%F-%T") }}'
+  when: not finalizer_run | bool
 
 - name: Set backup directory name
   set_fact:
     backup_dir: "/backups/eda-openshift-backup-{{ now }}"
+  when: not finalizer_run | bool
 
 - name: Create directory for backup
   k8s_exec:
@@ -108,3 +110,4 @@
     pod: "{{ ansible_operator_meta.name }}-db-management"
     command: >-
       mkdir -p {{ backup_dir }}
+  when: not finalizer_run | bool


### PR DESCRIPTION
The postgres_skip_data refactor (#353) moved backup_dir/timestamp
setup into init.yml, which finalizer.yml also runs on CR deletion.
set_fact overwrote the block-scoped backup_dir passed in from CR
status, so delete_backup.yml deleted a freshly created empty
directory instead of the real backup, silently breaking
clean_backup_on_delete.

Guards the three affected tasks with `when: not finalizer_run | bool`,
matching the existing finalizer_run branching in main.yml.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented backup initialization and backup-directory creation during finalizer execution.
  * Ensured backup timestamps and directory naming are handled only during regular runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->