### PR TITLE
[AAP-89728]fix: mounts the ca bundle correctly and does some DRY work

### DIFF
--- a/roles/eda/templates/ca-mount-fragment.yaml.j2
+++ b/roles/eda/templates/ca-mount-fragment.yaml.j2
@@ -1,0 +1,8 @@
+{% if bundle_ca_crt %}
+- name: "ca-trust-extracted"
+  mountPath: "/etc/pki/ca-trust/extracted"
+- name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+  mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+  subPath: bundle-ca.crt
+  readOnly: true
+{% endif %}

--- a/roles/eda/templates/eda-api.deployment.yaml.j2
+++ b/roles/eda/templates/eda-api.deployment.yaml.j2
@@ -362,14 +362,7 @@ spec:
         - name: static-files
           mountPath: {{ static_path }}
 {% endif %}
-{% if bundle_ca_crt %}
-        - name: "ca-trust-extracted"
-          mountPath: "/etc/pki/ca-trust/extracted"
-        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
-          mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
-          subPath: bundle-ca.crt
-          readOnly: true
-{% endif %}
+        {{lookup("template", "ca-mount-fragment.yaml.j2") | indent(width=8) | trim }}
 {% endif %}
       - name: daphne
         image: {{ _image }}
@@ -422,12 +415,7 @@ spec:
 {% endif %}
 {% if bundle_ca_crt %}
         volumeMounts:
-          - name: "ca-trust-extracted"
-            mountPath: "/etc/pki/ca-trust/extracted"
-          - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
-            mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
-            subPath: bundle-ca.crt
-            readOnly: true
+        {{lookup("template", "ca-mount-fragment.yaml.j2") | indent(width=8) | trim }}
 {% endif %}
       - name: nginx
         image: {{ _image_web }}


### PR DESCRIPTION
addresses AAP-89728 and properly mounts the ca-bundle to the eda-api pod.  It also does a little refactoring to dry out some templating that is used by the eda-api and the daphne pods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional mounting of the CA trust directory and bundle certificate into containers.
  * Mounted the bundle certificate as read-only when CA bundling is enabled.

* **Refactor**
  * Standardized CA certificate volume mounts across API and Daphne containers for more consistent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->